### PR TITLE
Use the latest spack executables in the pre-industrial config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,14 +10,14 @@ submodels:
     - name: atmosphere
       model: um
       ncpus: 192
-      exe: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/um_hg3.exe-20240307
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/um7-git.2024.05.21_7.3-zh77vblf4kbj6g6f56nllygk7nk65l5n/bin/um_hg3.exe
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/atmosphere
 
     - name: ocean
       model: mom
       ncpus: 180
-      exe: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/mom5xx
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.access-esm1.5_2024.05.24_access-esm1.5-2bfrfafe46wrb6iuhksa6jjcevhnjn3z/bin/fms_ACCESS-CM.x
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/ocean/common
         - /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial
@@ -25,7 +25,7 @@ submodels:
     - name: ice
       model: cice
       ncpus: 12
-      exe: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/cice4.1_access-mct-12p-20240307
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/cice4-git.2024.05.21_access-esm1.5-bp4fqohyjqde7jb2l663sargto3smceu/bin/cice_access_360x300_12x1_12p.exe
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/ice
 
@@ -36,7 +36,7 @@ submodels:
         - /g/data/access/payu/access-esm/input/pre-industrial/coupler
 
 collate:
-   exe: /g/data/access/payu/access-esm/bin/mppnccombine
+   exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.access-esm1.5_2024.05.24_access-esm1.5-2bfrfafe46wrb6iuhksa6jjcevhnjn3z/bin/mppnccombine.spack
    restart: true
    mem: 4GB
 

--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ submodels:
         - /g/data/access/payu/access-esm/input/pre-industrial/coupler
 
 collate:
-   exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.access-esm1.5_2024.05.24_access-esm1.5-2bfrfafe46wrb6iuhksa6jjcevhnjn3z/bin/mppnccombine.spack
+   exe: /g/data/access/payu/access-esm/bin/mppnccombine
    restart: true
    mem: 4GB
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,14 +10,14 @@ submodels:
     - name: atmosphere
       model: um
       ncpus: 192
-      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/um7-git.2024.05.21_7.3-zh77vblf4kbj6g6f56nllygk7nk65l5n/bin/um_hg3.exe
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.07.03_access-esm1.5-sgtnpkn2y4sa7rpwkcoj2vwaqg63wb46/bin/um_hg3.exe
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/atmosphere
 
     - name: ocean
       model: mom
       ncpus: 180
-      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/mom5-git.access-esm1.5_2024.05.24_access-esm1.5-2bfrfafe46wrb6iuhksa6jjcevhnjn3z/bin/fms_ACCESS-CM.x
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.06.20_access-esm1.5-6dlcxvntncmxxwsboq2xtao3dfzrvsl2/bin/fms_ACCESS-CM.x
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/ocean/common
         - /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial
@@ -25,7 +25,7 @@ submodels:
     - name: ice
       model: cice
       ncpus: 12
-      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64/intel-19.0.5.281/cice4-git.2024.05.21_access-esm1.5-bp4fqohyjqde7jb2l663sargto3smceu/bin/cice_access_360x300_12x1_12p.exe
+      exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.2024.05.21_access-esm1.5-hl7736a47pat6l33vsku3yadrudoqe3q/bin/cice_access_360x300_12x1_12p.exe
       input:
         - /g/data/access/payu/access-esm/input/pre-industrial/ice
 
@@ -36,7 +36,7 @@ submodels:
         - /g/data/access/payu/access-esm/input/pre-industrial/coupler
 
 collate:
-   exe: /g/data/access/payu/access-esm/bin/mppnccombine
+   exe: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.06.20_access-esm1.5-6dlcxvntncmxxwsboq2xtao3dfzrvsl2/bin/mppnccombine.spack
    restart: true
    mem: 4GB
 

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -1,18 +1,18 @@
 format: yamanifest
 version: 1.0
 ---
-work/atmosphere/um_hg3.exe-20240307:
-  fullpath: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/um_hg3.exe-20240307
+work/atmosphere/um_hg3.exe:
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.07.03_access-esm1.5-sgtnpkn2y4sa7rpwkcoj2vwaqg63wb46/bin/um_hg3.exe
   hashes:
-    binhash: 1b9fd068aba4a75e2eb834c38fd22788
-    md5: a9058e2abd586e8d1c17ec63a42b6136
-work/ice/cice4.1_access-mct-12p-20240307:
-  fullpath: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/cice4.1_access-mct-12p-20240307
+    binhash: b577004c8c3fecdb96a5cfac43270d6f
+    md5: d6b46a1c8cd550b72de90f3b1e878c03
+work/ice/cice_access_360x300_12x1_12p.exe:
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.2024.05.21_access-esm1.5-hl7736a47pat6l33vsku3yadrudoqe3q/bin/cice_access_360x300_12x1_12p.exe
   hashes:
-    binhash: 304441ddc6e49d7c60eefb9b93c68f3c
-    md5: 3436f0b59e13cc280783ee00dd1d3bc7
-work/ocean/mom5xx:
-  fullpath: /g/data/tm70/pcl851/src/penguian/access-esm-build-gadi/bin/mom5xx
+    binhash: a830239468e63f62592640a3d2ac77a2
+    md5: abf06f178ebca026ccf6ccef65b927d1
+work/ocean/fms_ACCESS-CM.x:
+  fullpath: /g/data/vk83/prerelease/apps/spack/0.21/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.06.20_access-esm1.5-6dlcxvntncmxxwsboq2xtao3dfzrvsl2/bin/fms_ACCESS-CM.x
   hashes:
-    binhash: 649b9210bb53a899ccaaa38f04b3f0d8
-    md5: 32007df52d8be049857e2a1335289116
+    binhash: 6232f5dfee4ca50725fecd4d90505c91
+    md5: 4534874bfcac23502c314ddede65d668

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -29,8 +29,8 @@ work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_
 work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv:
   fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv
   hashes:
-    binhash: 89260b97f347f244e3afa35df0cbcb51
-    md5: 109d0702afd2cb0a66bf141faccaee30
+    binhash: e7e2567e4109446b57a49e6ef15e683b
+    md5: a526e6d3a2ad2e24d069a3b9a572def7
 work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv:
   fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv
   hashes:


### PR DESCRIPTION
Closes #16
The `payu` test run reproduces the relevant outputs bitwise.
 
