### PR TITLE
37 update input paths pre-industrial

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -1,7 +1,7 @@
 &cable
 !
- filename%veg     = 'INPUT/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt' !relative to your home dir
- filename%soil    = 'INPUT/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt' !relative to your home dir
+ filename%veg     = 'INPUT/def_veg_params.txt' !relative to your home dir
+ filename%soil    = 'INPUT/def_soil_params.txt' !relative to your home dir
 !
 !
 !! cable_user flags
@@ -53,7 +53,7 @@
   l_laiFeedbk   = .TRUE.  ! using prognostic LAI
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
-!  casafile%cnpbiome='INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
-  casafile%cnpbiome='INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
-  casafile%phen='INPUT/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
+!  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
+  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
+  casafile%phen='INPUT/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
 &end

--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -1,7 +1,7 @@
 &cable
 !
- filename%veg     = 'INPUT/def_veg_params.txt' !relative to your home dir
- filename%soil    = 'INPUT/def_soil_params.txt' !relative to your home dir
+ filename%veg     = 'INPUT/def_veg_params.txt'
+ filename%soil    = 'INPUT/def_soil_params.txt'
 !
 !
 !! cable_user flags
@@ -53,7 +53,6 @@
   l_laiFeedbk   = .TRUE.  ! using prognostic LAI
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
-!  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
   casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
   casafile%phen='INPUT/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
 &end

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,7 @@ submodels:
       ncpus: 192
       exe: um_hg3.exe
       input:
+        # Aerosols
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
@@ -25,10 +26,10 @@ submodels:
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
-
+        # Forcing
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
-
+        # Land
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
@@ -36,13 +37,13 @@ submodels:
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
-
+        # Spectral
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
-
+        # Grids
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
-
+        # STASH
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
 
     - name: ocean
@@ -50,39 +51,41 @@ submodels:
       ncpus: 180
       exe: fms_ACCESS-CM.x
       input:
+        # Biogeochemistry
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
-
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
-
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
-        
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
-
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
-
-
+        # Tides
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+        # Shortwave
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        # Grids
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        
     - name: ice
       model: cice
       ncpus: 12
       exe: cice_access_360x300_12x1_12p.exe
       input:
+        # Grids
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
-
+        # Climatology
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
+        # Grids
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
-
+        # Remapping weights
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
         - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc

--- a/config.yaml
+++ b/config.yaml
@@ -2,9 +2,10 @@ jobname: pre-industrial
 queue: normal
 walltime: 2:00:00
 
+# Modules for loading model executables
 modules:
   use:
-      - /g/data/vk83/apps/spack/0.22/release/modules/linux-rocky8-x86_64_v4
+      - /g/data/vk83/modules/access-models/
   load:
       - access-esm1p5/2024.05.0
 

--- a/config.yaml
+++ b/config.yaml
@@ -18,28 +18,78 @@ submodels:
       ncpus: 192
       exe: um_hg3.exe
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/atmosphere
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
 
     - name: ocean
       model: mom
       ncpus: 180
       exe: fms_ACCESS-CM.x
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/ocean/common
-        - /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+
 
     - name: ice
       model: cice
       ncpus: 12
       exe: cice_access_360x300_12x1_12p.exe
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/ice
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/coupler
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
 
 collate:
     exe: mppnccombine.spack
@@ -47,7 +97,7 @@ collate:
     mem: 4GB
     walltime: 1:00:00
 
-restart: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/
+restart: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/
 
 calendar:
     start:

--- a/config.yaml
+++ b/config.yaml
@@ -71,7 +71,6 @@ submodels:
       exe: cice_access_360x300_12x1_12p.exe
       input:
         # Grids
-        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
         # Climatology

--- a/config.yaml
+++ b/config.yaml
@@ -19,32 +19,32 @@ submodels:
       exe: um_hg3.exe
       input:
         # Aerosols
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
         # Forcing
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
         # Land
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
         # Spectral
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
         # STASH
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
 
     - name: ocean
       model: mom
@@ -52,18 +52,18 @@ submodels:
       exe: fms_ACCESS-CM.x
       input:
         # Biogeochemistry
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
         # Tides
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
         # Shortwave
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
         
     - name: ice
       model: cice
@@ -71,28 +71,28 @@ submodels:
       exe: cice_access_360x300_12x1_12p.exe
       input:
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
         # Climatology
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
         # Remapping weights
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
 
 collate:
     exe: mppnccombine.spack
@@ -100,7 +100,7 @@ collate:
     mem: 4GB
     walltime: 1:00:00
 
-restart: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/
+restart: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/
 
 calendar:
     start:

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,407 +2,342 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/INPUT/BC_hi_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/BC_hi_1850_ESM1.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
   hashes:
-    binhash: 701eb25da0f3c9b0a430da1b51449a0a
+    binhash: 8c9b22313e991592bb684c3395926c80
     md5: 74803eb36a358f9ac8ecdae36cdb7f56
 work/atmosphere/INPUT/Bio_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/Bio_1850_ESM1.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
   hashes:
-    binhash: bc0648b654c77fd6ec194f0ebc5ee489
+    binhash: 436a287e78437b62498457a78d93211c
     md5: 69dc6afb4bc7524d346f3b82f2657c97
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt
-  hashes:
-    binhash: 29a05874c8b52806ec4273e04df58e62
-    md5: a7b89d25cff82cf13cf812a98ad3a029
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv
-  hashes:
-    binhash: 25dbaecf930f7f09243984e1f247a4a2
-    md5: 8a0fd917ed5f20bb055decef119d394e
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_spinup.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_spinup.csv
-  hashes:
-    binhash: cc36f541c3cfa76bd1ca1767441878d1
-    md5: 043997298518f6d819f49634e8948be4
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv
-  hashes:
-    binhash: d5dcc7c9459d4d9080733782abbab4af
-    md5: a526e6d3a2ad2e24d069a3b9a572def7
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv
-  hashes:
-    binhash: 94ffafc2c12869e0c89c6d7933b932d1
-    md5: 6a4ee7bbb2e7bd074be9d036bf40d9e2
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt
-  hashes:
-    binhash: 72cff3be9be9a986ec2a530732e5af39
-    md5: 93107e8c37e04ccf97471fd2ac8f63eb
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt
-  hashes:
-    binhash: 27a407dd57b0ceba94c9bbb2be3346b8
-    md5: 1f9a27f0e252bf6c466100573c126789
 work/atmosphere/INPUT/DMS_conc.N96:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/DMS_conc.N96
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
   hashes:
-    binhash: 56eda93e098dfefdef6d44a0bf06e958
+    binhash: cbf986b9291704eb6ca48fb85cc309e9
     md5: 7e8ec8de832c0b9b8c1d9f0eda4d54e5
 work/atmosphere/INPUT/Ndep_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/Ndep_1850_ESM1.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
   hashes:
-    binhash: 0eeb7a9a885bc51be3b28b546a8f6d2d
+    binhash: 97a1fe836679853405009550a3b3f90c
     md5: 48462cfa1aeed200c3b8d0bf1b49654a
 work/atmosphere/INPUT/OCFF_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/OCFF_1850_ESM1.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
   hashes:
-    binhash: 2e48b826853e9ea77aa3e2571428770f
+    binhash: 8a358c0fca6c9dc7aa49586f504cf524
     md5: 95eec04860fa30ee863d30e67e683407
-work/atmosphere/INPUT/SOURCES:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/SOURCES
-  hashes:
-    binhash: 23f2d99ea24c4ae416249f6fd10f3a46
-    md5: 5b3a5f40cb3a2ba0df1f3251e65194b6
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_A
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
   hashes:
-    binhash: ac186e9b28d4ee478477d5e3532f9c85
+    binhash: 813b5a254f5666450760da386ef43db4
     md5: 74cbbb76edfbd9f7c4b928609c00cd64
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A.original:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_A.original
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
   hashes:
-    binhash: fc8c2bab866aa0c4212fc553bba90485
+    binhash: 8afe63c1aacc00f778c69872516c96c9
     md5: ed1004d9aca8d29baba143ea12defbb7
 work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_O
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
   hashes:
-    binhash: a372d2fa943fb85027b7dfba31c71642
+    binhash: c644fb6c73afdf5eefd0e0086976d44b
     md5: 5a65d77c62d55e3b62e35ad9662d32a9
 work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_S
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
   hashes:
-    binhash: d8e16218632dd3befe53a79bf7547072
+    binhash: 241ae9a0dce937389f133d383024aaac
     md5: 85ff5d563968cf24d1be595b05b4e52d
 work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_W
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
   hashes:
-    binhash: 4b5c5ff64c2c06becea4b20f89bb2600
+    binhash: f00ee794e8453bb6e386ac36a04ca757
     md5: 1e4391ea1f6234b33c33168bd7089d06
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHsections_A
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
   hashes:
-    binhash: f714ff1636e91b87b4a6cb0083178ef8
+    binhash: 2f4b6af4ec50f1bea692ecbc0f935bc9
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/biogenic_351sm.N96L38:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/biogenic_351sm.N96L38
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
   hashes:
-    binhash: a807429d641a78a039eb70ba5bd5d83b
+    binhash: 4016048ec8e26e6f84a868c1161e59a3
     md5: 55eb75f602a4639fb3c8ff40e36eb661
 work/atmosphere/INPUT/cable_vegfunc_N96.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/cable_vegfunc_N96.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
   hashes:
-    binhash: 9cf1500dd7a40cea7ef044db06a4b60b
+    binhash: 4df1a198560578ae763526c730158cfd
     md5: 7a8cb16191ad29b081514657893530c6
+work/atmosphere/INPUT/def_soil_params.txt:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+  hashes:
+    binhash: cde42a0c3d2324eb21bcf03b25d1201d
+    md5: 93107e8c37e04ccf97471fd2ac8f63eb
+work/atmosphere/INPUT/def_veg_params.txt:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+  hashes:
+    binhash: b4b2451b7f18d24e39749388a77180aa
+    md5: 1f9a27f0e252bf6c466100573c126789
+work/atmosphere/INPUT/modis_phenology_csiro.txt:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+  hashes:
+    binhash: f519783ccfc63db8f88a82e6ca9f0a27
+    md5: a7b89d25cff82cf13cf812a98ad3a029
 work/atmosphere/INPUT/ozone_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/ozone_1850_ESM1.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
   hashes:
-    binhash: d44cd5fe376e4e153623081280c51b4b
+    binhash: 33522e53c88a05d43aa891f172b289c7
     md5: a64a01e3b092085fca308524a75a1cee
-work/atmosphere/INPUT/qrclim.slt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrclim.slt
+work/atmosphere/INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
   hashes:
-    binhash: 5c318ecae39e1378f5a7ada4300bacbf
-    md5: dfb5e52b445917514e5c6ce2ac208c46
-work/atmosphere/INPUT/qrclim.smow:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrclim.smow
-  hashes:
-    binhash: 89d726f96d65a5e8521aa5f99162fd38
-    md5: 89d4912892b8ebd22329dd131d326ccc
+    binhash: 1e98e47a305625ece80283331f01b863
+    md5: 109d0702afd2cb0a66bf141faccaee30
 work/atmosphere/INPUT/qrparm.mask:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrparm.mask
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:
-    binhash: a22afcd1049c436678fc4141444c78af
+    binhash: d2d38fcb1eebdb0b419fcb2249075c23
     md5: f497c7827bd22ef0b98f1d1af776866d
 work/atmosphere/INPUT/qrparm.soil_igbp_vg:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrparm.soil_igbp_vg
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
   hashes:
-    binhash: 05814fc5223ef02de546fbee4e3efd1e
+    binhash: deb56e757c2f4e4b84cef33dd7d2b23a
     md5: 26ce57f462dd574fe49f290ab7877112
 work/atmosphere/INPUT/scycl_1850_ESM1_v4.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/scycl_1850_ESM1_v4.anc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
   hashes:
-    binhash: bbd36c569e37ce440db4b9730ae9aa87
+    binhash: 7236ee314d8f707ce8d6f7292e12393d
     md5: 2c390f44c4f57078340cfbd408fdc754
 work/atmosphere/INPUT/spec3a_lw_hadgem1_6on:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/spec3a_lw_hadgem1_6on
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
   hashes:
-    binhash: 6ee819e5786ee14f09abd3132d2063f6
+    binhash: 452161a3f5a54223fd593fb998aa5c59
     md5: 9ff85916dbb36ba6679b954d16387aee
 work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/spec3a_sw_hadgem1_6on
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
   hashes:
-    binhash: 39915c6c90e4df40fb0a716deec55249
+    binhash: b11add15022f62b14afbd36de8a5d81f
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01001218
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01001218
   hashes:
-    binhash: 1db5f5eaa1ab9031fc60a9742f6dc786
+    binhash: ed688987bfeb737222589f3f4359f2f1
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01002207
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01002207
   hashes:
-    binhash: fa4dd82bb4fd4f24f365bc085bffefcc
+    binhash: 0d63fef5e7f439a04f232c71328d0db7
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003236
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003236
   hashes:
-    binhash: 59b02f84687c3edb381992a7b7af8a4e
+    binhash: 59866396fdc710bce6bbeedfae3a49ca
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003237
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003237
   hashes:
-    binhash: 84863390648c70d1360358170c53ef32
+    binhash: 2abd1d19974787fbd9404ccfec4062c1
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003254
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003254
   hashes:
-    binhash: 092893a6e38ab9444bec295a698d2e77
+    binhash: 9cb711f2d6f22b52c915a383f9bf675e
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003255
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003255
   hashes:
-    binhash: 53c751c78cdb9787e8c6d3b69d1d2701
+    binhash: 35a005ca3e1c3ea88968d7e7d650e9ee
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003274
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003274
   hashes:
-    binhash: 179e605ff71ca5cebaa2464339841eb9
+    binhash: c2aa7644544dec51efbf4194a3026557
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003275
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003275
   hashes:
-    binhash: fd74988066a6923977793f5ff3db291b
+    binhash: 544af1e8e4f2f708e918cc7421422943
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003276
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003276
   hashes:
-    binhash: 1b5620001d4698e4b2cc89acfdf68d4d
+    binhash: a8c416736c912739dfbb0cc306d09156
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003277
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003277
   hashes:
-    binhash: 057139598531a1504822a8e751cc3fe2
+    binhash: d5d4ff715e406e2750fe55df1d45061b
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003278
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003278
   hashes:
-    binhash: ba5c1b3908374514ff3118300dc9142a
+    binhash: 33f7c4974f5803841d3f178757bc2543
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003279
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003279
   hashes:
-    binhash: 750706183ec07d2b7c025b9e34c042b9
+    binhash: 05f597a9dde6264059dd1c1f049869c1
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003280
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003280
   hashes:
-    binhash: 61e9175373ae5b64e4d1919d2395ccbd
+    binhash: c1b894221e36b1787100c0b05a4f7eef
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003281
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003281
   hashes:
-    binhash: da9064719c9433460454afacb71ca8d0
+    binhash: c484fe2e43beaff653a99b08d5b24a49
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003286
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003286
   hashes:
-    binhash: 97fd89e81f26f8f7a0c1a850e06c7884
+    binhash: febe4d4416b0593a02dc87cfc88b150a
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005207
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005207
   hashes:
-    binhash: 14e3b782aa9d7783e477a33b49221886
+    binhash: ffbd233c57d1eaa191e8b36f0cc7a3c2
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005208
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005208
   hashes:
-    binhash: 3eedbfef9f6a72949516b85a8758a777
+    binhash: 9dc09e05d369c3af54c5fad4e22c7ab3
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005222
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005222
   hashes:
-    binhash: 490a886ba428213a47d8221d36cf06e9
+    binhash: 673ae4983cfac79f7c499fca140bc8b2
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005223
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005223
   hashes:
-    binhash: 1bab12d4f494d342afef7b2e5e51f50d
+    binhash: a109b98228c058253bf5b80b6c9ddbf9
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01010206
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01010206
   hashes:
-    binhash: 5c51a194f6aff3c0bfb761305f1b57c0
+    binhash: 368e441eec8c5a1ff0555c255eea6afe
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/sulpc_oxidants_N96_L38
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:
-    binhash: 4edf15d33d8c6141783b3839e67762d6
+    binhash: 0bb61cf0a1d470fb5798688580284d0b
     md5: 7c42d1faf74b2b9f6819f2349a8d0d25
 work/atmosphere/INPUT/vertlevs_G3:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/vertlevs_G3
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
   hashes:
-    binhash: f3f8df2649679869cf7a543e659b6782
+    binhash: 89f1d61fecb388a00636c827d97648c7
     md5: 58ca02de69b16bd59771c81e06c4c21a
 work/atmosphere/INPUT/volcts_18502000ave.dat:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/volcts_18502000ave.dat
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
   hashes:
-    binhash: c7862f8b76a43ae07cbb471c59051d46
+    binhash: e1c3f66fdb65250bc58c8139a52b29e6
     md5: 47bd369c750be55d706ab60c78bc7aee
 work/coupler/areas.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/areas.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
   hashes:
-    binhash: 21cae1a43f7d3e6eb774ac420d0b182b
+    binhash: 70548e6301fa3280ea4a1daa517f3372
     md5: 1aac9e2f82d96176f7b87ba1efc8784e
-work/coupler/cf_name_table.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/cf_name_table.txt
-  hashes:
-    binhash: a0cc87db3a4ac852c87412db6b4ad252
-    md5: 74333d6fa3153ac294a74a506792375c
 work/coupler/grids.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/grids.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
   hashes:
-    binhash: 097cf63ad3cd82cc20aa0baa5364f952
+    binhash: d420eafedc3b15015501043aacae0d0a
     md5: 2348de62f5fe4d55ec849f79e5d027fd
 work/coupler/masks.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/masks.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
   hashes:
-    binhash: c6d82f6152364d083b0870d17718fbbc
+    binhash: 433ccede4284c6511911ef0e26b16702
     md5: 0a12503901fd3d595bc25b5d3008f9d3
 work/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: a18e25b2be0c9b5f54275749e15f777d
+    binhash: 3da2f284e9e28a23f91708d0b10eadc5
     md5: a8129dba5b3a7f70a5bc2fbf7f0e4f68
 work/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 6cfe2d688759dc7edda7643c9f6730c2
+    binhash: 9bf9e5e77d72f26aec86e877db4249d3
     md5: 6fc856e7c2014e20903a01cdd61f4f2c
 work/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 0f259452f418298d6dfb7b7047616c72
+    binhash: 6778c0da4c8792e6e724d34c7b88acab
     md5: a2a7d940a9eaab59ec8fa49154116a64
 work/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
   hashes:
-    binhash: 3e40a993ca21b7d8f0431307a92dee93
+    binhash: cab31779c0dfc56f3d135604c5d29e03
     md5: 25be6489585df07097d4b6009bf23ec2
 work/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 7d0c9d98e764d4c27a134d9a3577b466
+    binhash: 126ae5f0466b3359b9e6245b6ed50878
     md5: 269086623444b48d0cd481e69d4bdc5f
 work/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 83a4e000c728a5312bc9265838ee4185
+    binhash: 7304e31fc9cadbaaec46bd2d880a2552
     md5: 58ea836bf1e12d5fc21460763b02548f
 work/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 020d985b81c6c7a6e2e44b8e89ee2d43
+    binhash: a055350241d10200eab15ac4d1474b2d
     md5: 3bf9569f34b657f2ecab8ef5c93e7659
 work/ice/INPUT/grid.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/grid.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
   hashes:
-    binhash: c0e1fc33b9cf16ed53b32c77af275e18
+    binhash: 610e9f5abc0583bfe67058e5ba4a1090
     md5: 1213e346055ee073fe33dc12578d99c6
 work/ice/INPUT/kmt.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/kmt.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
   hashes:
-    binhash: 15455ece12e3ea26f56f0272d1f2a6f2
+    binhash: e7c97a616d26529d02550365a70d3f10
     md5: 2bde88b9e44c46aecf2ba2dff188d1ac
 work/ice/INPUT/monthly_sstsss.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/monthly_sstsss.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
   hashes:
-    binhash: 2128e978f4ff9631d31687d3400e38f9
+    binhash: 2912bf96b404bbc258b0ac29f93dc2e5
     md5: 323d4c605f83f4d7d3126da70153c2ed
-work/ocean/INPUT/basin_mask.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/basin_mask.nc
-  hashes:
-    binhash: 9c273f0ed87133742865d04ee655eaa8
-    md5: 20fd8740f24ca95c7c086343077e9c0d
 work/ocean/INPUT/bgc_param.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/bgc_param.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
   hashes:
-    binhash: 2ab0de4b6a7453d14376cc2c4a4615c5
-    md5: 7162c91ab9399c7a225fcb03593843ee
-work/ocean/INPUT/cfc_auscom.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/cfc_auscom.nc
-  hashes:
-    binhash: 075ccc190b2467f6d33d0f77a3728fd5
-    md5: 38660c8a5de3e3b63d2ae7ba5020d515
-work/ocean/INPUT/co2_obs.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/co2_obs.nc
-  hashes:
-    binhash: ae85b0b6712c9faf6973d1b004286272
-    md5: bfc3011737ab384d770b937b269e50fc
+    binhash: 7d37cd5fa7d997e660efd6d9cf65f8b1
+    md5: 9defb35e7a7181e9170a6ae57a4d3348
 work/ocean/INPUT/dust.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/dust.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
   hashes:
-    binhash: 374b73916dc4f04f36a1bc4316fd8071
+    binhash: 26bc2f5ce1efaec22b61c7e5436b5a3e
     md5: bfbbea8ac46a932d0ec8631afbfc2ae2
-work/ocean/INPUT/geothermal_heating.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/geothermal_heating.nc
-  hashes:
-    binhash: 2314e8fcafc7279c2ebecac7f55d5a1e
-    md5: 381cb231d8d059576adca0c2bea9c030
 work/ocean/INPUT/grid_spec.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/grid_spec.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
   hashes:
-    binhash: 00361652bc2eb575ccaa26a2a49323e3
+    binhash: 623f0c8a401432427a6c89564b8a0f62
     md5: b9adc1e552201aa3abc6efb72786ec93
-work/ocean/INPUT/ocmip2_abiotic_c14_atm_hist_om3_bc-1-9999.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_abiotic_c14_atm_hist_om3_bc-1-9999.nc
-  hashes:
-    binhash: 2b8ebb65bc9a0da54478293e7e000b56
-    md5: e91a04235ab63ef060d0c6e350ed9581
 work/ocean/INPUT/ocmip2_fice_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_fice_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
   hashes:
-    binhash: 73881ad2628a5608e35773732f23f38b
+    binhash: c88a9d880a8fdf81cc298afac6257c60
     md5: c0ed75eef44962dbe6fc9f61dbd228a9
 work/ocean/INPUT/ocmip2_press_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_press_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
   hashes:
-    binhash: 1a034ba81daf08808e82762a0d22eef3
+    binhash: 1f3621ba5a5e80fd346a52717efa5fff
     md5: 2e71cbb78c052e06e3df20f862928da2
-work/ocean/INPUT/ocmip2_siple_co2_atm_am2_bc-1-9999.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_siple_co2_atm_am2_bc-1-9999.nc
-  hashes:
-    binhash: 49878db364d6b7d04be26aa19875af97
-    md5: bf1db4228eeacb676da968073b8c5848
 work/ocean/INPUT/ocmip2_xkw_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_xkw_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
   hashes:
-    binhash: fa7e5087f8421bed7d69124f94975d91
+    binhash: 09bac4f0f0da3edf1a7eb0ea9a262fab
     md5: 348a035bed83e280bb0a1de0066947fc
 work/ocean/INPUT/roughness_amp.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/roughness_amp.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
   hashes:
-    binhash: 6b1194d04fda9027a0f0928e39e8be1c
+    binhash: 75d84af9e09b02d00f7be29eef7a5dbc
     md5: 185dadeb53da2de75b47c53fd7085f89
 work/ocean/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/ssw_atten_depth.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
   hashes:
-    binhash: 6a4a2c066c9c7cbc34035bfcd5d855d6
+    binhash: fd668293ec6ede1f82667f0fa449138d
     md5: 3e88b51db135788aa4348d58cbeabfad
 work/ocean/INPUT/tideamp.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/tideamp.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
   hashes:
-    binhash: 9e635a2039b0c2f39e2c131e03f5527b
+    binhash: fe958e4c8e68b35c7e3f4becbd8b337a
     md5: b2840af757d9b7b40207f33f1fc84c5c

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,342 +2,347 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/INPUT/BC_hi_1850_ESM1.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/BC_hi_1850_ESM1.anc
   hashes:
-    binhash: 8c9b22313e991592bb684c3395926c80
+    binhash: a98741eb50f16483786933e6bbd700e3
     md5: 74803eb36a358f9ac8ecdae36cdb7f56
 work/atmosphere/INPUT/Bio_1850_ESM1.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/Bio_1850_ESM1.anc
   hashes:
-    binhash: 436a287e78437b62498457a78d93211c
+    binhash: 4ee80aefae4975731a21667b5b26343f
     md5: 69dc6afb4bc7524d346f3b82f2657c97
 work/atmosphere/INPUT/DMS_conc.N96:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
   hashes:
-    binhash: cbf986b9291704eb6ca48fb85cc309e9
+    binhash: da1baa25e78ec281c82ea4588e30a340
     md5: 7e8ec8de832c0b9b8c1d9f0eda4d54e5
 work/atmosphere/INPUT/Ndep_1850_ESM1.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/land/biogeochemistry/global.N96/2020.05.19/Ndep_1850_ESM1.anc
   hashes:
-    binhash: 97a1fe836679853405009550a3b3f90c
+    binhash: 47374849ef42f83e3c02629827a482ee
     md5: 48462cfa1aeed200c3b8d0bf1b49654a
 work/atmosphere/INPUT/OCFF_1850_ESM1.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/OCFF_1850_ESM1.anc
   hashes:
-    binhash: 8a358c0fca6c9dc7aa49586f504cf524
+    binhash: 0ec3fde7a17984009b8d90ff1ddbc92f
     md5: 95eec04860fa30ee863d30e67e683407
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
   hashes:
-    binhash: 813b5a254f5666450760da386ef43db4
+    binhash: 4f75001536d84c87362b607aa42c4f61
     md5: 74cbbb76edfbd9f7c4b928609c00cd64
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A.original:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
   hashes:
-    binhash: 8afe63c1aacc00f778c69872516c96c9
+    binhash: c7d3efdc2ca645724064afc4f7e655f6
     md5: ed1004d9aca8d29baba143ea12defbb7
 work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
   hashes:
-    binhash: c644fb6c73afdf5eefd0e0086976d44b
+    binhash: 763bf187687a18a505264b4b79d40153
     md5: 5a65d77c62d55e3b62e35ad9662d32a9
 work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
   hashes:
-    binhash: 241ae9a0dce937389f133d383024aaac
+    binhash: 6d6eb7e1e0f21e635e532202f7b8d462
     md5: 85ff5d563968cf24d1be595b05b4e52d
 work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
   hashes:
-    binhash: f00ee794e8453bb6e386ac36a04ca757
+    binhash: 919a2c8987bd593c78153ff323efeb51
     md5: 1e4391ea1f6234b33c33168bd7089d06
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
   hashes:
-    binhash: 2f4b6af4ec50f1bea692ecbc0f935bc9
+    binhash: 9401083e4199439b77254fc490b6597d
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/biogenic_351sm.N96L38:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
   hashes:
-    binhash: 4016048ec8e26e6f84a868c1161e59a3
+    binhash: 35f8585c3290dfc25ed19e7d93f6a1bb
     md5: 55eb75f602a4639fb3c8ff40e36eb661
 work/atmosphere/INPUT/cable_vegfunc_N96.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
   hashes:
-    binhash: 4df1a198560578ae763526c730158cfd
+    binhash: b590c62f20575a65f1f5ee83ec687304
     md5: 7a8cb16191ad29b081514657893530c6
 work/atmosphere/INPUT/def_soil_params.txt:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
   hashes:
-    binhash: cde42a0c3d2324eb21bcf03b25d1201d
+    binhash: f6bbe84fb16971f00d2ba34eef542976
     md5: 93107e8c37e04ccf97471fd2ac8f63eb
 work/atmosphere/INPUT/def_veg_params.txt:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
   hashes:
-    binhash: b4b2451b7f18d24e39749388a77180aa
+    binhash: 22ce1f400a832868aefeaa9721ac3a48
     md5: 1f9a27f0e252bf6c466100573c126789
 work/atmosphere/INPUT/modis_phenology_csiro.txt:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
   hashes:
-    binhash: f519783ccfc63db8f88a82e6ca9f0a27
+    binhash: a86ffb366359d6d353c6f385789185a1
     md5: a7b89d25cff82cf13cf812a98ad3a029
 work/atmosphere/INPUT/ozone_1850_ESM1.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/global.N96/2020.05.19/ozone_1850_ESM1.anc
   hashes:
-    binhash: 33522e53c88a05d43aa891f172b289c7
+    binhash: 7e82d4a83bf18e59277f026cbbee4c74
     md5: a64a01e3b092085fca308524a75a1cee
 work/atmosphere/INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
   hashes:
-    binhash: 1e98e47a305625ece80283331f01b863
+    binhash: 7b29e253f569372abb0a5f2769b58a3d
     md5: 109d0702afd2cb0a66bf141faccaee30
 work/atmosphere/INPUT/qrparm.mask:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:
-    binhash: d2d38fcb1eebdb0b419fcb2249075c23
+    binhash: 6d189a763e3418d2cf61581eded5522e
     md5: f497c7827bd22ef0b98f1d1af776866d
 work/atmosphere/INPUT/qrparm.soil_igbp_vg:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
   hashes:
-    binhash: deb56e757c2f4e4b84cef33dd7d2b23a
+    binhash: 51560dde970f7123a7250cc6bdc8f3ef
     md5: 26ce57f462dd574fe49f290ab7877112
 work/atmosphere/INPUT/scycl_1850_ESM1_v4.anc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/aerosol/global.N96/2020.05.19/scycl_1850_ESM1_v4.anc
   hashes:
-    binhash: 7236ee314d8f707ce8d6f7292e12393d
+    binhash: 4dac8b00fc0b26a086f2dd9e610aba6a
     md5: 2c390f44c4f57078340cfbd408fdc754
 work/atmosphere/INPUT/spec3a_lw_hadgem1_6on:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
   hashes:
-    binhash: 452161a3f5a54223fd593fb998aa5c59
+    binhash: 278569974348c9583fe0a2a9e1828ffd
     md5: 9ff85916dbb36ba6679b954d16387aee
 work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
   hashes:
-    binhash: b11add15022f62b14afbd36de8a5d81f
+    binhash: 149899ecc54ed754ab8c6f05cb99f140
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01001218
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01001218
   hashes:
-    binhash: ed688987bfeb737222589f3f4359f2f1
+    binhash: cef321aa4d4eeae2d156db854ce276c4
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01002207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01002207
   hashes:
-    binhash: 0d63fef5e7f439a04f232c71328d0db7
+    binhash: 4e7a1dc7a52a0aab1da67b9328510fb5
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003236
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003236
   hashes:
-    binhash: 59866396fdc710bce6bbeedfae3a49ca
+    binhash: 5cdf6aea7e61410df48d3cac8469454d
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003237
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003237
   hashes:
-    binhash: 2abd1d19974787fbd9404ccfec4062c1
+    binhash: 883c4ddd6d137ac441bf6c045c8a1c39
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003254
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003254
   hashes:
-    binhash: 9cb711f2d6f22b52c915a383f9bf675e
+    binhash: e6db920da74cdf06c3c32053d778e9f3
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003255
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003255
   hashes:
-    binhash: 35a005ca3e1c3ea88968d7e7d650e9ee
+    binhash: 9b804470b184c2e3a143a64314b4baf3
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003274
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003274
   hashes:
-    binhash: c2aa7644544dec51efbf4194a3026557
+    binhash: a999c69b36a2f7d183e8b9fce0b17dba
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003275
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003275
   hashes:
-    binhash: 544af1e8e4f2f708e918cc7421422943
+    binhash: 24c47dd90d0a17b6fa81e48133f310e3
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003276
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003276
   hashes:
-    binhash: a8c416736c912739dfbb0cc306d09156
+    binhash: 9c8d8aa71ac65ee098ac3a50f00007c3
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003277
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003277
   hashes:
-    binhash: d5d4ff715e406e2750fe55df1d45061b
+    binhash: da58ccbd06fe6cf6987f8eef37590c70
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003278
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003278
   hashes:
-    binhash: 33f7c4974f5803841d3f178757bc2543
+    binhash: 5a899ad334e42cc3cdd1ab14429299ed
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003279
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003279
   hashes:
-    binhash: 05f597a9dde6264059dd1c1f049869c1
+    binhash: a43fcc064f100a634326d53110ab8fe2
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003280
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003280
   hashes:
-    binhash: c1b894221e36b1787100c0b05a4f7eef
+    binhash: 05b3ac5c90fdf71e906e3b6e0dcf3329
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003281
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003281
   hashes:
-    binhash: c484fe2e43beaff653a99b08d5b24a49
+    binhash: 990649b208fa059df477aef96d2242a0
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003286
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003286
   hashes:
-    binhash: febe4d4416b0593a02dc87cfc88b150a
+    binhash: 731b64153656addbd7bd29b98e60906a
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005207
   hashes:
-    binhash: ffbd233c57d1eaa191e8b36f0cc7a3c2
+    binhash: 52ae55398cdcdf5582bd6253755c5185
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005208
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005208
   hashes:
-    binhash: 9dc09e05d369c3af54c5fad4e22c7ab3
+    binhash: 4d114e56511e247ca65b4bd79cd66437
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005222
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005222
   hashes:
-    binhash: 673ae4983cfac79f7c499fca140bc8b2
+    binhash: 115879288e4fe41cf3aa936793597f0a
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005223
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005223
   hashes:
-    binhash: a109b98228c058253bf5b80b6c9ddbf9
+    binhash: b0707253914846f3a526030c52a818fe
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01010206
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01010206
   hashes:
-    binhash: 368e441eec8c5a1ff0555c255eea6afe
+    binhash: a7c6cf46b049f520547eab48654687ad
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:
-    binhash: 0bb61cf0a1d470fb5798688580284d0b
+    binhash: e8b31e6ca1af7da756d87243e622e3c8
     md5: 7c42d1faf74b2b9f6819f2349a8d0d25
 work/atmosphere/INPUT/vertlevs_G3:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
   hashes:
-    binhash: 89f1d61fecb388a00636c827d97648c7
+    binhash: 67eeeb98a7de5eee305f026a20482cc7
     md5: 58ca02de69b16bd59771c81e06c4c21a
 work/atmosphere/INPUT/volcts_18502000ave.dat:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/atmosphere/forcing/resolution_independent/2020.05.19/volcts_18502000ave.dat
   hashes:
-    binhash: e1c3f66fdb65250bc58c8139a52b29e6
+    binhash: 34b64995370a775e276c7a270aa659a7
     md5: 47bd369c750be55d706ab60c78bc7aee
 work/coupler/areas.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
   hashes:
-    binhash: 70548e6301fa3280ea4a1daa517f3372
+    binhash: 74a0105eb80df5993bef82be279536ee
     md5: 1aac9e2f82d96176f7b87ba1efc8784e
 work/coupler/grids.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
   hashes:
-    binhash: d420eafedc3b15015501043aacae0d0a
+    binhash: dd60e450879fe3d1bc8697179b2bb68e
     md5: 2348de62f5fe4d55ec849f79e5d027fd
 work/coupler/masks.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
   hashes:
-    binhash: 433ccede4284c6511911ef0e26b16702
+    binhash: 9372991dd00c8f0d9a2aeb97fb36d1f1
     md5: 0a12503901fd3d595bc25b5d3008f9d3
 work/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 3da2f284e9e28a23f91708d0b10eadc5
+    binhash: 10999c39f61114a78b187ec0f98cd3f6
     md5: a8129dba5b3a7f70a5bc2fbf7f0e4f68
 work/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 9bf9e5e77d72f26aec86e877db4249d3
+    binhash: 1d0f36698633414416f8e744c88e2746
     md5: 6fc856e7c2014e20903a01cdd61f4f2c
 work/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 6778c0da4c8792e6e724d34c7b88acab
+    binhash: 059755d03c22fc3f8d05af551a2f8efb
     md5: a2a7d940a9eaab59ec8fa49154116a64
 work/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
   hashes:
-    binhash: cab31779c0dfc56f3d135604c5d29e03
+    binhash: 32ae62df22794a672138d9b1e4f78dd5
     md5: 25be6489585df07097d4b6009bf23ec2
 work/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 126ae5f0466b3359b9e6245b6ed50878
+    binhash: 79c6f6f8817db2cf95dc815fcd84bc3f
     md5: 269086623444b48d0cd481e69d4bdc5f
 work/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 7304e31fc9cadbaaec46bd2d880a2552
+    binhash: 130343da4a880b8d9f3e210eec37a556
     md5: 58ea836bf1e12d5fc21460763b02548f
 work/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: a055350241d10200eab15ac4d1474b2d
+    binhash: 89de238897ba6f06a4c9a1bcefe4ebc8
     md5: 3bf9569f34b657f2ecab8ef5c93e7659
 work/ice/INPUT/grid.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
   hashes:
-    binhash: 610e9f5abc0583bfe67058e5ba4a1090
+    binhash: e27f1045f956550305426c6abb36c868
     md5: 1213e346055ee073fe33dc12578d99c6
 work/ice/INPUT/kmt.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
   hashes:
-    binhash: e7c97a616d26529d02550365a70d3f10
+    binhash: 0ed504b151b168eebdee3aa13edd8c37
     md5: 2bde88b9e44c46aecf2ba2dff188d1ac
 work/ice/INPUT/monthly_sstsss.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
   hashes:
-    binhash: 2912bf96b404bbc258b0ac29f93dc2e5
+    binhash: 49aab10f25c58a9a0ffa5617847050ff
     md5: 323d4c605f83f4d7d3126da70153c2ed
-work/ocean/INPUT/bgc_param.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+work/ice/INPUT/ssw_atten_depth.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
   hashes:
-    binhash: 7d37cd5fa7d997e660efd6d9cf65f8b1
+    binhash: 4a66b77be6d419706657e3fe3e5bf210
+    md5: 3e88b51db135788aa4348d58cbeabfad
+work/ocean/INPUT/bgc_param.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+  hashes:
+    binhash: 69340d523fddf842e3e7a030eb139111
     md5: 9defb35e7a7181e9170a6ae57a4d3348
 work/ocean/INPUT/dust.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
   hashes:
-    binhash: 26bc2f5ce1efaec22b61c7e5436b5a3e
+    binhash: 89983106fff4813c347b2e98a8f62f52
     md5: bfbbea8ac46a932d0ec8631afbfc2ae2
 work/ocean/INPUT/grid_spec.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
   hashes:
-    binhash: 623f0c8a401432427a6c89564b8a0f62
+    binhash: 20468cf509d14ec15c908f7fbd8b3de5
     md5: b9adc1e552201aa3abc6efb72786ec93
 work/ocean/INPUT/ocmip2_fice_monthly_om1p5_bc.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
   hashes:
-    binhash: c88a9d880a8fdf81cc298afac6257c60
+    binhash: 60f4723017d75ebe8a5bc5fe0f37ad1d
     md5: c0ed75eef44962dbe6fc9f61dbd228a9
 work/ocean/INPUT/ocmip2_press_monthly_om1p5_bc.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
   hashes:
-    binhash: 1f3621ba5a5e80fd346a52717efa5fff
+    binhash: d4b3605e8765d477b02a55d6ae21feac
     md5: 2e71cbb78c052e06e3df20f862928da2
 work/ocean/INPUT/ocmip2_xkw_monthly_om1p5_bc.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
   hashes:
-    binhash: 09bac4f0f0da3edf1a7eb0ea9a262fab
+    binhash: 39f04199eedf0e3a6c638d890795311e
     md5: 348a035bed83e280bb0a1de0066947fc
 work/ocean/INPUT/roughness_amp.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
   hashes:
-    binhash: 75d84af9e09b02d00f7be29eef7a5dbc
+    binhash: 9283cb9b6093d7d9570797f360062d10
     md5: 185dadeb53da2de75b47c53fd7085f89
 work/ocean/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
   hashes:
-    binhash: fd668293ec6ede1f82667f0fa449138d
+    binhash: 4a66b77be6d419706657e3fe3e5bf210
     md5: 3e88b51db135788aa4348d58cbeabfad
 work/ocean/INPUT/tideamp.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
   hashes:
-    binhash: fe958e4c8e68b35c7e3f4becbd8b337a
+    binhash: f20fffd2f2b42e73b177b439b006751d
     md5: b2840af757d9b7b40207f33f1fc84c5c

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -296,11 +296,6 @@ work/ice/INPUT/monthly_sstsss.nc:
   hashes:
     binhash: 49aab10f25c58a9a0ffa5617847050ff
     md5: 323d4c605f83f4d7d3126da70153c2ed
-work/ice/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
-  hashes:
-    binhash: 4a66b77be6d419706657e3fe3e5bf210
-    md5: 3e88b51db135788aa4348d58cbeabfad
 work/ocean/INPUT/bgc_param.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
   hashes:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -2,270 +2,270 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/PI-02.astart-01010101:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/PI-02.astart-01010101
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/PI-02.astart-01010101
   hashes:
-    binhash: 75b9a141bf9e087d360bd3e3c62f0859
+    binhash: d329a23a6d7563038e2165a4e17c7907
     md5: bfc4e6d8dfdb52d75e870adf62f2fb54
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/restart_dump.astart
   hashes:
-    binhash: 070bc0108d4b98c281b9af927b6e9e80
+    binhash: 5f4953143e0976cade7ee5a907e2e545
     md5: bfc4e6d8dfdb52d75e870adf62f2fb54
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc
   hashes:
-    binhash: a7354932d77f224c4e40c4c43986d8cc
+    binhash: c26f2d428ef4c2abbae0d9761ee66b29
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/a2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc-01001231
   hashes:
-    binhash: 6d3f98e926dd72bcc4034426bfb8b4e3
+    binhash: 6f3ad48a2fa712bb76e3ac102ae4898f
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc
   hashes:
-    binhash: 9f581a163b7c99c71035ce7f76cc3f04
+    binhash: 61a9e993e69761224538b39acc128fae
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/i2a.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc-01001231
   hashes:
-    binhash: cec43506c67bc472885dac8002769012
+    binhash: 7a3fba386f1f8738ddd4d59c41d9105c
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc
   hashes:
-    binhash: 9520b44fbbc52d19cc8377b5858f8fce
+    binhash: 53f914415f3f0c1ca4d7d64ce40b3ad1
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/coupler/o2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc-01001231
   hashes:
-    binhash: 1bfd4baed4e9acad1999985633df5c76
+    binhash: b54510d75d48b84bf1b1699e009356d2
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/ice/RESTART/cice_in.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/cice_in.nml
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/cice_in.nml
   hashes:
-    binhash: ad6d701947ea80c468ead53b3720e294
+    binhash: 065438e6ec01b615b9a50e9e8ee03eb6
     md5: 1576287c82da88ffc4752430100f848e
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file
   hashes:
-    binhash: 32d4802c9a47f54eabe932a90dbb8179
+    binhash: eb5295bbdde3f7455efdba11ad144b80
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/ice.restart_file-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file-01001231
   hashes:
-    binhash: a3e8109f7743c0c1a4405ff31e2ddf0c
+    binhash: 9b3ac58940a4f2a4c1ca3293fb6c9273
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/iced.01010101:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/iced.01010101
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/iced.01010101
   hashes:
-    binhash: 5a6f13fd6708df5ee9abd4d9929bbb03
+    binhash: adcef41f7c92083c581de75e620365ba
     md5: d9d2e6e475ab3f94518e170a64c8d43e
 work/ice/RESTART/input_ice.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/input_ice.nml
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/input_ice.nml
   hashes:
-    binhash: 7c5d6a08120bfd234ed2c8c97772d6a3
+    binhash: 7b2d9db31d115b61876a592a5cd34cb6
     md5: e2d6d0541795dd3eeae54cda28ecba96
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc
   hashes:
-    binhash: 75c0e095aa7647417a16e12cb84fad84
+    binhash: ad3fafbc52aee03ccac6970a239766e7
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ice/RESTART/mice.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc-01001231
   hashes:
-    binhash: 44a2a8b97c9e80c895181b637a419e21
+    binhash: 86630cac8e3acfb2d69f60a6d0e1e40b
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ocean/INPUT/csiro_bgc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc
   hashes:
-    binhash: a49e0b9ab875f75e87c634209005c04e
+    binhash: 50b9b440913a9daa607130bd7b45c5b3
     md5: 36eddc51730941934ad070439525719f
 work/ocean/INPUT/csiro_bgc.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc-01001231
   hashes:
-    binhash: 1e1edccc63759248b7302a1dd0032bc4
+    binhash: 928210b4949476e54d04e08f3462cba0
     md5: 36eddc51730941934ad070439525719f
 work/ocean/INPUT/csiro_bgc_sediment.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc
   hashes:
-    binhash: c9a6f66683c66ac5bb8b3d2b27b7055d
+    binhash: cdc3d3774ed0bb25492d4d4d0e2c705b
     md5: c19814b8cd24d34c1d0f6ede4b94426c
 work/ocean/INPUT/csiro_bgc_sediment.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc-01001231
   hashes:
-    binhash: c29d8379bfca34ce876cedd942923e32
+    binhash: 87d4ba06bcd55dd60fc841f2eecd96f5
     md5: c19814b8cd24d34c1d0f6ede4b94426c
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc
   hashes:
-    binhash: b7c57cb49ef465c777592de5fba4864d
+    binhash: 73b781f7e79c5382d43c69513e567cb7
     md5: 5ad601c0eaad3cfc3baa47aed91d1af9
 work/ocean/INPUT/ocean_age.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc-01001231
   hashes:
-    binhash: a3ab2eb551db91c1e74cf2b27d13922f
+    binhash: 1e3ba44dedaefef5367d23eac1be5a40
     md5: 5ad601c0eaad3cfc3baa47aed91d1af9
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc
   hashes:
-    binhash: 320ea61c1c0cdfb5464bbab8d67f79b0
+    binhash: a28a0924b37c8b22d11fdbffe5afc105
     md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
 work/ocean/INPUT/ocean_barotropic.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc-01001231
   hashes:
-    binhash: 628723da7033aa9bade84a80f3ca1247
+    binhash: 542dcc852c58bfbdb11e24d64d95cee3
     md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc
   hashes:
-    binhash: 77147b60171a2fe1517616fd72a0e2ef
+    binhash: 57f14885eabee760edbcd5dc03df110c
     md5: 78ebb71bbf0e28e14d72243cf48a483c
 work/ocean/INPUT/ocean_bih_friction.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc-01001231
   hashes:
-    binhash: 79bc55f61aa80e17d58ee9ecb79afe6d
+    binhash: a426565293270cd2462ed2cdad99f578
     md5: 78ebb71bbf0e28e14d72243cf48a483c
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc
   hashes:
-    binhash: fe92b6cc5df5586370ffebbd853ebb89
+    binhash: 1683d1032fb56b5f0cf63a890db0e0f4
     md5: 2ea72f188feac5017d4c7456f514e1e6
 work/ocean/INPUT/ocean_density.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc-01001231
   hashes:
-    binhash: 01f62acf571c278d9db613bfd468146a
+    binhash: 4260aa4bd911e556a70bcb647bca1fd3
     md5: 2ea72f188feac5017d4c7456f514e1e6
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc
   hashes:
-    binhash: d4e48982b316229f715bfd6fe24ad7a3
+    binhash: 59f983ebd48d8bb4b85e9a12671917bb
     md5: dfd57082dc58081e9ed6b515f2d8a4c1
 work/ocean/INPUT/ocean_frazil.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc-01001231
   hashes:
-    binhash: c2f69eb3087600c07a1e8c25dae29e9a
+    binhash: a147b08214b0455f3c2800ea11a8a66d
     md5: dfd57082dc58081e9ed6b515f2d8a4c1
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc
   hashes:
-    binhash: 00822106ad44d79d6279d14856c8d1d8
+    binhash: 98f2376bee37c48160d09d8d090867b9
     md5: 2c1dbc74450e72925f9dbe7486689675
 work/ocean/INPUT/ocean_lap_friction.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc-01001231
   hashes:
-    binhash: f97607f96b117ca198ba4eae782c0266
+    binhash: 8b79f4303773f488dda707f553da81a8
     md5: 2c1dbc74450e72925f9dbe7486689675
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc
   hashes:
-    binhash: daaeec49618220fe5e51102ab0d18d76
+    binhash: b619d96024d81f27c146d5f1aee761a4
     md5: fab54ae81945add9ae5e850a4569ec34
 work/ocean/INPUT/ocean_neutral.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc-01001231
   hashes:
-    binhash: c279ed585c7cef708c1e05347a05cb70
+    binhash: b3fec4ad12347677f30d4018801d0d92
     md5: fab54ae81945add9ae5e850a4569ec34
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc
   hashes:
-    binhash: 57139f1276cc928c359fb893516750ec
+    binhash: a5728081144e58008d000ee065410e00
     md5: dd179d49d13b0b11d524df725b6eec05
 work/ocean/INPUT/ocean_pot_temp.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc-01001231
   hashes:
-    binhash: b530b074fe5f8843e15576c07f747b59
+    binhash: 5a3c1fde21c74f43dc49bd2c698d2daf
     md5: dd179d49d13b0b11d524df725b6eec05
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc
   hashes:
-    binhash: 04ffd4ac80ecd33b259f1ecccc9646e3
+    binhash: fa7eb79171d6283309af858214d8a6d8
     md5: 655ee14d694588f2cdb870535df0b042
 work/ocean/INPUT/ocean_sbc.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc-01001231
   hashes:
-    binhash: 931cdc40d6994f6701b4b87f03ad5984
+    binhash: ebe0aa5c179eb6338b5ae01e0ff2f8d9
     md5: 655ee14d694588f2cdb870535df0b042
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc
   hashes:
-    binhash: cd0d14258f92d245e9ea1ce33027f8f0
+    binhash: 1eb6035036f07358de1f9a03908d94f6
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_sigma_transport.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc-01001231
   hashes:
-    binhash: 9e3b8327c883761d6abd47a98107f5bc
+    binhash: b48ff814f83971448582e87949ec0942
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res
   hashes:
-    binhash: fc8097e0252143f2b4896b4961f47bf4
+    binhash: 612a0d10f3acfcf78d4a5fa9473eb369
     md5: 354221e55782d6c1ffff3f9c3df24ffd
 work/ocean/INPUT/ocean_solo.res-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res-01001231
   hashes:
-    binhash: 0b0640f4b6608524247571bff0841436
+    binhash: ec55bd0b47af8eebb336209a97374bd8
     md5: 354221e55782d6c1ffff3f9c3df24ffd
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc
   hashes:
-    binhash: 66a2a1b9f7077179beb4b9e720e6218b
+    binhash: 9f79790fcff30cd2284562045ee319d0
     md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
 work/ocean/INPUT/ocean_temp_salt.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc-01001231
   hashes:
-    binhash: 1233f438473e41b1079e4e62adabec45
+    binhash: e6b495d0e4069924232b98de2a7aec31
     md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc
   hashes:
-    binhash: 1e3f9a22f8c816b1b4607a55f59b9f47
+    binhash: 5d4f9bde26e4554fb34c5b9ea7dac325
     md5: 5a9bbbca1e6fd2c963db84dda5a84acf
 work/ocean/INPUT/ocean_thickness.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc-01001231
   hashes:
-    binhash: 657bf15d72a0c81b1a836afd5a9e1481
+    binhash: 3028db01d30344e471073d3890342a66
     md5: 5a9bbbca1e6fd2c963db84dda5a84acf
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res
   hashes:
-    binhash: 8316399e3fffdd4f0c737fa464407f40
+    binhash: 4219ff58220b565482be8527fba50863
     md5: 5e5db59b3963b8130ccc76557ed2badc
 work/ocean/INPUT/ocean_tracer.res-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res-01001231
   hashes:
-    binhash: 10a1f328675501dead6887bcd3fbc3ef
+    binhash: 8d45c50d4bcf443522a542f53688fe08
     md5: 5e5db59b3963b8130ccc76557ed2badc
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc
   hashes:
-    binhash: f1d91a163c32193f34bfa1eb1bebbec6
+    binhash: f63778183617313c83dbecc57619837c
     md5: 287edec7690400b797b1cbf6e1ea60f0
 work/ocean/INPUT/ocean_velocity.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc-01001231
   hashes:
-    binhash: 338bb6a0301d35dcae1ffdd67888f81a
+    binhash: bdf81d0ca54d8864be40a48abe551395
     md5: 287edec7690400b797b1cbf6e1ea60f0
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc
   hashes:
-    binhash: 6316797e712748033daf21da9fbf2544
+    binhash: 99a342d73a013f4caf0c5e2d11a90a40
     md5: 653ffae21c9f0a18718d441d591798a1
 work/ocean/INPUT/ocean_velocity_advection.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc-01001231
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc-01001231
   hashes:
-    binhash: d3bc0ddcf0d0b464214a1958f5661e63
+    binhash: 2c53fe3165c904bde1fbdf2723dae5cc
     md5: 653ffae21c9f0a18718d441d591798a1

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -2,270 +2,270 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/PI-02.astart-01010101:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/atmosphere/PI-02.astart-01010101
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/PI-02.astart-01010101
   hashes:
-    binhash: 300f9de33e694974e0ffb34c5041fbf1
+    binhash: 75b9a141bf9e087d360bd3e3c62f0859
     md5: bfc4e6d8dfdb52d75e870adf62f2fb54
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/atmosphere/restart_dump.astart
   hashes:
-    binhash: c653332ef8696a0b27551e4a6241e311
+    binhash: 070bc0108d4b98c281b9af927b6e9e80
     md5: bfc4e6d8dfdb52d75e870adf62f2fb54
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/a2i.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc
   hashes:
-    binhash: 865aa0b412ab1e570e9ef1f53251b51c
+    binhash: a7354932d77f224c4e40c4c43986d8cc
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/a2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/a2i.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/a2i.nc-01001231
   hashes:
-    binhash: 750e3f6feab83cb274e57dc725c6218d
+    binhash: 6d3f98e926dd72bcc4034426bfb8b4e3
     md5: c8f135384aaf0b9a9119a441f76d3f32
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/i2a.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc
   hashes:
-    binhash: 045f72939f4117657b60d6960d63f23f
+    binhash: 9f581a163b7c99c71035ce7f76cc3f04
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/i2a.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/i2a.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/i2a.nc-01001231
   hashes:
-    binhash: 551ddde24989ccaaef2d4cdc1c223ca2
+    binhash: cec43506c67bc472885dac8002769012
     md5: 87e48c0403e304fe20d21cb277dcc07a
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/o2i.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc
   hashes:
-    binhash: 0b5b65fa303182f18988679791585857
+    binhash: 9520b44fbbc52d19cc8377b5858f8fce
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/coupler/o2i.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/coupler/o2i.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/coupler/o2i.nc-01001231
   hashes:
-    binhash: 801f7f24e144e274c957b29854efebfd
+    binhash: 1bfd4baed4e9acad1999985633df5c76
     md5: b724ded00ce0f5ad5984b61bee1ad43e
 work/ice/RESTART/cice_in.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/cice_in.nml
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/cice_in.nml
   hashes:
-    binhash: 3925dc2fe387a104e3d53ee74fcb0f35
+    binhash: ad6d701947ea80c468ead53b3720e294
     md5: 1576287c82da88ffc4752430100f848e
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/ice.restart_file
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file
   hashes:
-    binhash: d4e3689437ff35ba0994f797ecc52902
+    binhash: 32d4802c9a47f54eabe932a90dbb8179
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/ice.restart_file-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/ice.restart_file-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/ice.restart_file-01001231
   hashes:
-    binhash: 4b3832c8775cbbeb9f69762712e1772c
+    binhash: a3e8109f7743c0c1a4405ff31e2ddf0c
     md5: 2b181afa9524673b64612f3094427fbe
 work/ice/RESTART/iced.01010101:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/iced.01010101
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/iced.01010101
   hashes:
-    binhash: e864d0e6ca91b44feec3fccb27ebfedf
+    binhash: 5a6f13fd6708df5ee9abd4d9929bbb03
     md5: d9d2e6e475ab3f94518e170a64c8d43e
 work/ice/RESTART/input_ice.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/input_ice.nml
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/input_ice.nml
   hashes:
-    binhash: 46cb6438ba0e192eef4221c617135796
+    binhash: 7c5d6a08120bfd234ed2c8c97772d6a3
     md5: e2d6d0541795dd3eeae54cda28ecba96
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/mice.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc
   hashes:
-    binhash: 0868deb2dd34d06f0567c1980045e353
+    binhash: 75c0e095aa7647417a16e12cb84fad84
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ice/RESTART/mice.nc-01001231:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ice/mice.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ice/mice.nc-01001231
   hashes:
-    binhash: 4f8adb52607c7757c71621c7f2dd89bc
+    binhash: 44a2a8b97c9e80c895181b637a419e21
     md5: 380a7008500f58eb5e8006b1eac18527
 work/ocean/INPUT/csiro_bgc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/csiro_bgc.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc
   hashes:
-    binhash: 553edebd6a8eae2431139bacee16b347
+    binhash: a49e0b9ab875f75e87c634209005c04e
     md5: 36eddc51730941934ad070439525719f
 work/ocean/INPUT/csiro_bgc.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/csiro_bgc.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc-01001231
   hashes:
-    binhash: 5532349f625fa1de16ecbab5308f4f02
+    binhash: 1e1edccc63759248b7302a1dd0032bc4
     md5: 36eddc51730941934ad070439525719f
 work/ocean/INPUT/csiro_bgc_sediment.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc
   hashes:
-    binhash: 161688a1e68b9202d6f74a80387ce2e3
+    binhash: c9a6f66683c66ac5bb8b3d2b27b7055d
     md5: c19814b8cd24d34c1d0f6ede4b94426c
 work/ocean/INPUT/csiro_bgc_sediment.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc_sediment.res.nc-01001231
   hashes:
-    binhash: 9bae29aed51df3266dfc45398c66ce7a
+    binhash: c29d8379bfca34ce876cedd942923e32
     md5: c19814b8cd24d34c1d0f6ede4b94426c
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc
   hashes:
-    binhash: f609b9fc2e5f5f6465f7ad13b0dba14d
+    binhash: b7c57cb49ef465c777592de5fba4864d
     md5: 5ad601c0eaad3cfc3baa47aed91d1af9
 work/ocean/INPUT/ocean_age.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_age.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_age.res.nc-01001231
   hashes:
-    binhash: 88037c5cd555cd1ee5f354798179e141
+    binhash: a3ab2eb551db91c1e74cf2b27d13922f
     md5: 5ad601c0eaad3cfc3baa47aed91d1af9
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc
   hashes:
-    binhash: c0df5186bd106deb855306c7e97c1ae7
+    binhash: 320ea61c1c0cdfb5464bbab8d67f79b0
     md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
 work/ocean/INPUT/ocean_barotropic.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_barotropic.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_barotropic.res.nc-01001231
   hashes:
-    binhash: f37fbda4e167c48d94d399fcb979cafe
+    binhash: 628723da7033aa9bade84a80f3ca1247
     md5: 97a5f4dc4a379ea4cad9f5d342ed6c51
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc
   hashes:
-    binhash: 5ee99015c9b6d30de214e7bf6fcdddb8
+    binhash: 77147b60171a2fe1517616fd72a0e2ef
     md5: 78ebb71bbf0e28e14d72243cf48a483c
 work/ocean/INPUT/ocean_bih_friction.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_bih_friction.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_bih_friction.res.nc-01001231
   hashes:
-    binhash: 77cfb744b5630a2bd9f12a8ec0774337
+    binhash: 79bc55f61aa80e17d58ee9ecb79afe6d
     md5: 78ebb71bbf0e28e14d72243cf48a483c
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc
   hashes:
-    binhash: 999fa84ff1c03979dcfc4df1b3d67cb0
+    binhash: fe92b6cc5df5586370ffebbd853ebb89
     md5: 2ea72f188feac5017d4c7456f514e1e6
 work/ocean/INPUT/ocean_density.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_density.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_density.res.nc-01001231
   hashes:
-    binhash: f3008ccd799d1f1aa4f44f74ba5515eb
+    binhash: 01f62acf571c278d9db613bfd468146a
     md5: 2ea72f188feac5017d4c7456f514e1e6
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc
   hashes:
-    binhash: f2edd39b90d80a346172493201dca100
+    binhash: d4e48982b316229f715bfd6fe24ad7a3
     md5: dfd57082dc58081e9ed6b515f2d8a4c1
 work/ocean/INPUT/ocean_frazil.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_frazil.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_frazil.res.nc-01001231
   hashes:
-    binhash: 78d8f6965b5647c65918295c0476aa9a
+    binhash: c2f69eb3087600c07a1e8c25dae29e9a
     md5: dfd57082dc58081e9ed6b515f2d8a4c1
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc
   hashes:
-    binhash: d01a93640ed85b4536e4c76304292816
+    binhash: 00822106ad44d79d6279d14856c8d1d8
     md5: 2c1dbc74450e72925f9dbe7486689675
 work/ocean/INPUT/ocean_lap_friction.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_lap_friction.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_lap_friction.res.nc-01001231
   hashes:
-    binhash: 5435f50042acbc0992b067d10f92cca2
+    binhash: f97607f96b117ca198ba4eae782c0266
     md5: 2c1dbc74450e72925f9dbe7486689675
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc
   hashes:
-    binhash: 0ffa676ef4dea0b83a9435367efce1e6
+    binhash: daaeec49618220fe5e51102ab0d18d76
     md5: fab54ae81945add9ae5e850a4569ec34
 work/ocean/INPUT/ocean_neutral.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_neutral.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_neutral.res.nc-01001231
   hashes:
-    binhash: 9f62cbdd870a76c81a391f073de01437
+    binhash: c279ed585c7cef708c1e05347a05cb70
     md5: fab54ae81945add9ae5e850a4569ec34
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc
   hashes:
-    binhash: 4f0e2928115b6971b2d00ac62ddafba0
+    binhash: 57139f1276cc928c359fb893516750ec
     md5: dd179d49d13b0b11d524df725b6eec05
 work/ocean/INPUT/ocean_pot_temp.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_pot_temp.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_pot_temp.res.nc-01001231
   hashes:
-    binhash: 1eb39622a862ef455e4f2ebec6513350
+    binhash: b530b074fe5f8843e15576c07f747b59
     md5: dd179d49d13b0b11d524df725b6eec05
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc
   hashes:
-    binhash: cca6c5ceb014272f3d273adb5e277830
+    binhash: 04ffd4ac80ecd33b259f1ecccc9646e3
     md5: 655ee14d694588f2cdb870535df0b042
 work/ocean/INPUT/ocean_sbc.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_sbc.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sbc.res.nc-01001231
   hashes:
-    binhash: b95e83ba1d7d4cf63519ecb728e966f9
+    binhash: 931cdc40d6994f6701b4b87f03ad5984
     md5: 655ee14d694588f2cdb870535df0b042
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc
   hashes:
-    binhash: f7be713105c0bc39cd742b71ae1566b9
+    binhash: cd0d14258f92d245e9ea1ce33027f8f0
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_sigma_transport.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_sigma_transport.res.nc-01001231
   hashes:
-    binhash: e83fe714cfc6973105ebf945cfdd74d7
+    binhash: 9e3b8327c883761d6abd47a98107f5bc
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res
   hashes:
-    binhash: 1dd8f3a80f0afba5f6d9659d12423b7e
+    binhash: fc8097e0252143f2b4896b4961f47bf4
     md5: 354221e55782d6c1ffff3f9c3df24ffd
 work/ocean/INPUT/ocean_solo.res-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_solo.res-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_solo.res-01001231
   hashes:
-    binhash: 084febda84f6c25e36c381ad88de8136
+    binhash: 0b0640f4b6608524247571bff0841436
     md5: 354221e55782d6c1ffff3f9c3df24ffd
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc
   hashes:
-    binhash: d82fb7cf08d93ab2c32a5c3d2b97d511
+    binhash: 66a2a1b9f7077179beb4b9e720e6218b
     md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
 work/ocean/INPUT/ocean_temp_salt.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_temp_salt.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_temp_salt.res.nc-01001231
   hashes:
-    binhash: fe1888a5a11673858bdf70f3bfea56b6
+    binhash: 1233f438473e41b1079e4e62adabec45
     md5: cd1b95ef3ac60f9e1f5af29d6bb2d4d5
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc
   hashes:
-    binhash: 74d7b2401380e46daa5e1df64c564970
+    binhash: 1e3f9a22f8c816b1b4607a55f59b9f47
     md5: 5a9bbbca1e6fd2c963db84dda5a84acf
 work/ocean/INPUT/ocean_thickness.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_thickness.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_thickness.res.nc-01001231
   hashes:
-    binhash: 75e810360cc066c032c0bd37a7fc38ea
+    binhash: 657bf15d72a0c81b1a836afd5a9e1481
     md5: 5a9bbbca1e6fd2c963db84dda5a84acf
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res
   hashes:
-    binhash: 65dd1aaba11d11d6483d5a5dc7d793b3
+    binhash: 8316399e3fffdd4f0c737fa464407f40
     md5: 5e5db59b3963b8130ccc76557ed2badc
 work/ocean/INPUT/ocean_tracer.res-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_tracer.res-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_tracer.res-01001231
   hashes:
-    binhash: 2df021889874d2a0346f07a30cb85502
+    binhash: 10a1f328675501dead6887bcd3fbc3ef
     md5: 5e5db59b3963b8130ccc76557ed2badc
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc
   hashes:
-    binhash: ce7a4d02d65dd05df00e49c7b00ffbbf
+    binhash: f1d91a163c32193f34bfa1eb1bebbec6
     md5: 287edec7690400b797b1cbf6e1ea60f0
 work/ocean/INPUT/ocean_velocity.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_velocity.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity.res.nc-01001231
   hashes:
-    binhash: 1a8f7447e346a0b92635d633c956bcee
+    binhash: 338bb6a0301d35dcae1ffdd67888f81a
     md5: 287edec7690400b797b1cbf6e1ea60f0
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc
   hashes:
-    binhash: 6d0e1ef20375d2289f4397bab2cdf57b
+    binhash: 6316797e712748033daf21da9fbf2544
     md5: 653ffae21c9f0a18718d441d591798a1
 work/ocean/INPUT/ocean_velocity_advection.res.nc-01001231:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc-01001231
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/ocean_velocity_advection.res.nc-01001231
   hashes:
-    binhash: 92eb270787b9427a594d58cf85b8f980
+    binhash: d3bc0ddcf0d0b464214a1958f5661e63
     md5: 653ffae21c9f0a18718d441d591798a1


### PR DESCRIPTION
This pull request updates the pre-industrial configuration with the new input paths using the restructured directory.

Note that the md5 hash for `pftlookup_csiro_v16_17tiles_wtlnds.csv` changed as there are slight differences between the `~access/payu` and the `vk83` versions of the file which [but the differences don't appear to be used by the model](https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/2#issuecomment-2190327672).
