### PR TITLE
37 update input paths historical

### DIFF
--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -1,7 +1,7 @@
 &cable
 !
- filename%veg     = 'INPUT/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt' !relative to your home dir
- filename%soil    = 'INPUT/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt' !relative to your home dir
+ filename%veg     = 'INPUT/def_veg_params.txt' !relative to your home dir
+ filename%soil    = 'INPUT/def_soil_params.txt' !relative to your home dir
 !
 !
 !! cable_user flags
@@ -55,7 +55,7 @@
   l_laiFeedbk   = .TRUE.  ! using prognostic LAI
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
-!  casafile%cnpbiome='INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
-  casafile%cnpbiome='INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
-  casafile%phen='INPUT/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
+!  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
+  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
+  casafile%phen='INPUT/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
 &end

--- a/atmosphere/cable.nml
+++ b/atmosphere/cable.nml
@@ -1,7 +1,7 @@
 &cable
 !
- filename%veg     = 'INPUT/def_veg_params.txt' !relative to your home dir
- filename%soil    = 'INPUT/def_soil_params.txt' !relative to your home dir
+ filename%veg     = 'INPUT/def_veg_params.txt'
+ filename%soil    = 'INPUT/def_soil_params.txt'
 !
 !
 !! cable_user flags
@@ -55,7 +55,6 @@
   l_laiFeedbk   = .TRUE.  ! using prognostic LAI
   l_vcmaxFeedbk = .TRUE.  ! using prognostic Vcmax
 ! filenames for CASA-CNP input files
-!  casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles.csv' ! biome specific BGC parameters
   casafile%cnpbiome='INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv'  ! biome specific BGC parameters
   casafile%phen='INPUT/modis_phenology_csiro.txt' ! phenology by latitude (modis derived)
 &end

--- a/config.yaml
+++ b/config.yaml
@@ -16,34 +16,34 @@ submodels:
       exe: /g/data/access/payu/access-esm/bin/coe/um7.3x
       input:
         # Aerosols
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
         # Forcing
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
         # Land        
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
         # Spectral        
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
         # STASH
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
 
     - name: ocean
       model: mom
@@ -51,18 +51,18 @@ submodels:
       exe: /g/data/access/payu/access-esm/bin/coe/mom5xx
       input:
         # Biogeochemistry      
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
         # Tides
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
         # Shortwave
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
 
     - name: ice
       model: cice
@@ -70,34 +70,34 @@ submodels:
       exe: /g/data/access/payu/access-esm/bin/coe/cicexx
       input:
         # Grids
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
         # Climatology
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
         # Grids      
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
         # Remapping weights
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
 
 collate:
    exe: /g/data/access/payu/access-esm/bin/mppnccombine
    restart: true
    mem: 4GB
 
-restart: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart
+restart: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart
 
 calendar:
     start:

--- a/config.yaml
+++ b/config.yaml
@@ -15,78 +15,82 @@ submodels:
       ncpus: 192
       exe: /g/data/access/payu/access-esm/bin/coe/um7.3x
       input:
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+        # Aerosols
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+        # Forcing
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
+        # Land        
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+        # Spectral        
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+        # Grids
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+        # STASH
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/
 
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
-        
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/
     - name: ocean
       model: mom
       ncpus: 180
       exe: /g/data/access/payu/access-esm/bin/coe/mom5xx
       input:
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
-        
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        # Biogeochemistry      
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+        # Tides
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+        # Shortwave
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        # Grids
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
 
     - name: ice
       model: cice
       ncpus: 12
       exe: /g/data/access/payu/access-esm/bin/coe/cicexx
       input:
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
+        # Grids
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+        # Climatology
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
-
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
-        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+        # Grids      
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+        # Remapping weights
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/vk83/experiments/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
 
 collate:
    exe: /g/data/access/payu/access-esm/bin/mppnccombine

--- a/config.yaml
+++ b/config.yaml
@@ -15,36 +15,85 @@ submodels:
       ncpus: 192
       exe: /g/data/access/payu/access-esm/bin/coe/um7.3x
       input:
-        - /g/data/vk83/experiments/inputs/access-esm1p5/historical/atmosphere
-        - /g/data/access/payu/access-esm/input/pre-industrial/atmosphere
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
 
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+        
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/
     - name: ocean
       model: mom
       ncpus: 180
       exe: /g/data/access/payu/access-esm/bin/coe/mom5xx
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/ocean/common
-        - /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
 
     - name: ice
       model: cice
       ncpus: 12
       exe: /g/data/access/payu/access-esm/bin/coe/cicexx
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/ice
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
 
     - name: coupler
       model: oasis
       ncpus: 0
       input:
-        - /g/data/access/payu/access-esm/input/pre-industrial/coupler
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+        - /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
 
 collate:
    exe: /g/data/access/payu/access-esm/bin/mppnccombine
    restart: true
    mem: 4GB
 
-restart: /g/data/vk83/experiments/inputs/access-esm1p5/historical/restart
+restart: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart
 
 calendar:
     start:

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,452 +2,352 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/INPUT/BC_hi_1849_2015_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/BC_hi_1849_2015_ESM1.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
   hashes:
-    binhash: 12993be791833bc6284f24d54c93baf4
-    md5: 29aa34a87e4874f0a4cd754b3c95b38b
-work/atmosphere/INPUT/BC_hi_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/BC_hi_1850_ESM1.anc
-  hashes:
-    binhash: bc9260e03478cf54f46d0ffaa01a7e97
-    md5: 74803eb36a358f9ac8ecdae36cdb7f56
+    binhash: 4f5918628037f3bc105ff728e88743e1
+    md5: f16cdb65e5d35103b1d7b7f45abcfffa
 work/atmosphere/INPUT/Bio_1849_2015_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/Bio_1849_2015_ESM1.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
   hashes:
-    binhash: 5a9350f8ea2072345f0a474c4d91640d
-    md5: 1198fb99e47ec3212389208bb1787ef1
-work/atmosphere/INPUT/Bio_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/Bio_1850_ESM1.anc
-  hashes:
-    binhash: 7cb0b8044130d3c5f2c0ea8f0f2cbc1c
-    md5: 69dc6afb4bc7524d346f3b82f2657c97
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/modis_phenology_csiro.txt
-  hashes:
-    binhash: 68c01888f6712e9da911d077ee95782b
-    md5: a7b89d25cff82cf13cf812a98ad3a029
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles.csv
-  hashes:
-    binhash: 1757e60323eb105fb90f3a46d5a16b64
-    md5: 8a0fd917ed5f20bb055decef119d394e
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_spinup.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_spinup.csv
-  hashes:
-    binhash: e590f919c9cace48520b41f68333fdba
-    md5: 043997298518f6d819f49634e8948be4
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/pftlookup_csiro_v16_17tiles_wtlnds.csv
-  hashes:
-    binhash: 89260b97f347f244e3afa35df0cbcb51
-    md5: 109d0702afd2cb0a66bf141faccaee30
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeochem/poolcnpInTumbarumba.csv
-  hashes:
-    binhash: 327d026055b05554a6ce5c9ffa7ebd1b
-    md5: 6a4ee7bbb2e7bd074be9d036bf40d9e2
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeophys/def_soil_params.txt
-  hashes:
-    binhash: 7cd52ceb7af7baa22048ecb7228dda6f
-    md5: 93107e8c37e04ccf97471fd2ac8f63eb
-work/atmosphere/INPUT/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/CABLE-AUX-1.4/core/biogeophys/def_veg_params.txt
-  hashes:
-    binhash: 3e4707bbcc9cb62678e65f9ba89cde7b
-    md5: 1f9a27f0e252bf6c466100573c126789
+    binhash: 8261c44d3d173d0aa146879d8c84b377
+    md5: fb650ff10a39596b92f67b1393c15289
 work/atmosphere/INPUT/DMS_conc.N96:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/DMS_conc.N96
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
   hashes:
-    binhash: 3bad0d245adf72c0b890611616484689
+    binhash: 1dbda8c60c4d62ef45f7e16f95a0ed5e
     md5: 7e8ec8de832c0b9b8c1d9f0eda4d54e5
 work/atmosphere/INPUT/Ndep_1849_2015.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/Ndep_1849_2015.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
   hashes:
-    binhash: 4fcffa5e717857a1ae6657d5107f481f
+    binhash: 9cc466ac85225df7b8cac75dbe75eef2
     md5: ff75533e9f52d92c42ac3556b4ec1fed
-work/atmosphere/INPUT/Ndep_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/Ndep_1850_ESM1.anc
-  hashes:
-    binhash: 37f9588daf45d2c0e0c5e73ab73a9ad5
-    md5: 48462cfa1aeed200c3b8d0bf1b49654a
 work/atmosphere/INPUT/OCFF_1849_2015_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/OCFF_1849_2015_ESM1.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
   hashes:
-    binhash: dfdee088c5aad3655964bacc68c75c79
-    md5: 42ccb16cd37ab12b49b2c115f8b3c29a
-work/atmosphere/INPUT/OCFF_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/OCFF_1850_ESM1.anc
-  hashes:
-    binhash: 1954cc8a3683ad325e3abf07b9d9abf0
-    md5: 95eec04860fa30ee863d30e67e683407
-work/atmosphere/INPUT/SOURCES:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/SOURCES
-  hashes:
-    binhash: 5892f86dafb3afbdfdfd05563ca6d8dc
-    md5: 5b3a5f40cb3a2ba0df1f3251e65194b6
+    binhash: 8254af51276a6bb45ff29676a3350903
+    md5: 1e38cac3a03101fb5aa5d88c713e809c
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_A
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
   hashes:
-    binhash: c4ffd1d4b34b3ff8149e5b0663d2c0f5
+    binhash: d3920a828b9e688d1f8a3e0072b0966c
     md5: 74cbbb76edfbd9f7c4b928609c00cd64
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A.original:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_A.original
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
   hashes:
-    binhash: 3bb06c3506095f7cf0a19b0450a29e2a
+    binhash: 71f58a61a27ec726505e4c6ef856015e
     md5: ed1004d9aca8d29baba143ea12defbb7
 work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_O
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
   hashes:
-    binhash: 55fa5cf8d7eafd10e8e196a7cde99c0d
+    binhash: 4c543a1a96f8c9ad683cb727392b628e
     md5: 5a65d77c62d55e3b62e35ad9662d32a9
 work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_S
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
   hashes:
-    binhash: 989ed21c9ed1ec9d1b307c6c5d9c5f27
+    binhash: e30f11b2cc9986c9d35df2444eeb5f6d
     md5: 85ff5d563968cf24d1be595b05b4e52d
 work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHmaster_W
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
   hashes:
-    binhash: 010ad808fa9c872498ac945045f15b5a
+    binhash: fe4b17e09dc200e53201c6f70df45e91
     md5: 1e4391ea1f6234b33c33168bd7089d06
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/STASHmaster/STASHsections_A
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
   hashes:
-    binhash: 6049f0c555b3c33d61bc3891f5a397c5
+    binhash: d7d9659dc6992445154811f780f2836e
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/TSI_CMIP6_ESM_v2:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/TSI_CMIP6_ESM_v2
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
   hashes:
-    binhash: cc14c34512c0c1141735af4d5969a9c9
+    binhash: 468a1106268925cd9d80f6a21eabafdd
     md5: 15aa13632aa616dcf079b152a5cbd120
 work/atmosphere/INPUT/biogenic_351sm.N96L38:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/biogenic_351sm.N96L38
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
   hashes:
-    binhash: 8ab4ff40358e274aa21d0240c8af2f71
+    binhash: 49e0bea671cc17c479424e81e77b3aca
     md5: 55eb75f602a4639fb3c8ff40e36eb661
 work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/cableCMIP6_LC_1850-2015.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
   hashes:
-    binhash: 306f76d4c25c43b70527c9f030bfdd13
-    md5: 425a2b30b996d40e34acd61d319a6faf
+    binhash: 397842d5ac8f889e9144cba9b72588a9
+    md5: 78ddfbdc9d9551cf6c6c39fe734716a4
 work/atmosphere/INPUT/cable_vegfunc_N96.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/cable_vegfunc_N96.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
   hashes:
-    binhash: a91053ef6f75a81581f28d0979e4d526
+    binhash: 99bd59c0f007fc09f5621ee56310d00a
     md5: 7a8cb16191ad29b081514657893530c6
+work/atmosphere/INPUT/def_soil_params.txt:
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+  hashes:
+    binhash: 2e9e0346384f9e6616e5f76b000a1450
+    md5: 93107e8c37e04ccf97471fd2ac8f63eb
+work/atmosphere/INPUT/def_veg_params.txt:
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+  hashes:
+    binhash: b431e3cba0955aff93a49fe91bcd4b41
+    md5: 1f9a27f0e252bf6c466100573c126789
+work/atmosphere/INPUT/modis_phenology_csiro.txt:
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+  hashes:
+    binhash: cd935a21abd6aace04b4ac6ea11f2f2a
+    md5: a7b89d25cff82cf13cf812a98ad3a029
 work/atmosphere/INPUT/ozone_1849_2015_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/ozone_1849_2015_ESM1.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
   hashes:
-    binhash: eecbb2a8383e88211e7ca64ee88bed6a
-    md5: 96cded5d4248c88e4088700778dc8557
-work/atmosphere/INPUT/ozone_1850_ESM1.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/ozone_1850_ESM1.anc
+    binhash: 22ffb9928874dc5bfcd35b813bdd9154
+    md5: b85f5374d1b89cf23cff05b6c35c4d0f
+work/atmosphere/INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv:
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
   hashes:
-    binhash: 839cf76c5a5784b294824cab29be9e54
-    md5: a64a01e3b092085fca308524a75a1cee
-work/atmosphere/INPUT/qrclim.slt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrclim.slt
-  hashes:
-    binhash: 3089b0c16e9020719069d301b0d97dab
-    md5: dfb5e52b445917514e5c6ce2ac208c46
-work/atmosphere/INPUT/qrclim.smow:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrclim.smow
-  hashes:
-    binhash: 360842c03286f8077514407200ac6f90
-    md5: 89d4912892b8ebd22329dd131d326ccc
+    binhash: b9625a4309cd3c6f9f0b7cfb685b1a5d
+    md5: 109d0702afd2cb0a66bf141faccaee30
 work/atmosphere/INPUT/qrparm.mask:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrparm.mask
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:
-    binhash: b6d3ecee861aa8cae1eea0b5981da0ae
+    binhash: 7fae36d3285eef1c799467116c4982a1
     md5: f497c7827bd22ef0b98f1d1af776866d
 work/atmosphere/INPUT/qrparm.soil_igbp_vg:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/qrparm.soil_igbp_vg
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
   hashes:
-    binhash: 132f243f6f1d47858f7b3f2a4d3f633b
+    binhash: 413eef63cfad90a94c0216157f4880cd
     md5: 26ce57f462dd574fe49f290ab7877112
 work/atmosphere/INPUT/scycl_1849_2015_ESM1_v4.anc:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/scycl_1849_2015_ESM1_v4.anc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
   hashes:
-    binhash: 98072431891242562534f91e8863a341
-    md5: 0d9c68fffff5f5ade1743e1b38fef323
-work/atmosphere/INPUT/scycl_1850_ESM1_v4.anc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/scycl_1850_ESM1_v4.anc
-  hashes:
-    binhash: 886a849242025c701b902f7a8b3ba23a
-    md5: 2c390f44c4f57078340cfbd408fdc754
+    binhash: 3cbf9138c2ffb3e62582df1c6ef9acc4
+    md5: 66ef33e0d38eb1a9f550766c1952a252
 work/atmosphere/INPUT/spec3a_lw_hadgem1_6on:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/spec3a_lw_hadgem1_6on
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
   hashes:
-    binhash: 7aabedffd6b0337c61b2da4e59bb9aae
+    binhash: 71592073489ce511f5b22629f3797195
     md5: 9ff85916dbb36ba6679b954d16387aee
 work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/spec3a_sw_hadgem1_6on
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
   hashes:
-    binhash: c8314789e828abdcc4777742c393813b
+    binhash: cc5a36a0f0729bc07907f8dbcf493ce7
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01001218
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01001218
   hashes:
-    binhash: 93bf8085cb83f8171cefff32ba30ef4b
+    binhash: eb961fc8eccd9a11c566abdff83e114a
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01002207
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01002207
   hashes:
-    binhash: 90a92e845c3ebe37a64650f33cb5547c
+    binhash: adb2608485efd33ee99d9edc47d8bf9c
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003236
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003236
   hashes:
-    binhash: be27f54c2339941ae1bd6ed537514b48
+    binhash: 0c9907a1bd062dea7ae253ec005ab745
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003237
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003237
   hashes:
-    binhash: b100b92024ccddcf65c9bf56a8e6719b
+    binhash: 2ffdc2d4dc0436f10a359579a8aaae1e
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003254
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003254
   hashes:
-    binhash: 2845b68eb9e79d204a0f68a8612c6dbe
+    binhash: b86c9c0ba28c227326fc327ae729c823
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003255
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003255
   hashes:
-    binhash: 198c4ca333599942fcf7325a96658c0a
+    binhash: 85db3e92f317067af18366ff4d64aa6c
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003274
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003274
   hashes:
-    binhash: f1cdac8e4c353df8b6533a79bf1253f9
+    binhash: 20801e04d6ff34e95f50c1151b95c774
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003275
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003275
   hashes:
-    binhash: cc3a7435be9e5134a0cdc0e459963c37
+    binhash: 2e08890e974c76d7c3861ea746a28d46
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003276
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003276
   hashes:
-    binhash: e3a8fe17cb457a58f2bceb00e30972be
+    binhash: 1b25673ce03da78d46a3bac4e4ad7b91
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003277
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003277
   hashes:
-    binhash: e0e70a36c2dabb38404c69481d382c20
+    binhash: ef28c2a6c67440e3eba2defe59e97ca7
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003278
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003278
   hashes:
-    binhash: 32d0f7279a5aaca35fce5c516d7cab2e
+    binhash: 1400c2b251d2b318fc23984566ce11bd
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003279
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003279
   hashes:
-    binhash: c799af05926991191a385f2e8996d681
+    binhash: e28e57094a8024634b11f9af265d9574
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003280
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003280
   hashes:
-    binhash: 9561430569dea93a48ca0e5c49934119
+    binhash: dbe15584ea0e14110d3cffc70822ef24
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003281
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003281
   hashes:
-    binhash: a6ddff528b91290d8307f485b619daa3
+    binhash: db854998561a42f136d1ff0a93e005d2
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01003286
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003286
   hashes:
-    binhash: 4118d063cbd8577e6acece9dd771cb79
+    binhash: 25865182a2ef2258f9265b6787466f0a
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005207
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005207
   hashes:
-    binhash: ee9ba5c5eaa1edafe3d633498ecdb21c
+    binhash: e906a4633db2e7081ca7290df98220ae
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005208
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005208
   hashes:
-    binhash: b2f7460f5b1759ab5f57f01d9097a9ae
+    binhash: a8a0cbbc62ab03db040a81ed5846db9f
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005222
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005222
   hashes:
-    binhash: 2345de38357898366664ee65c5417269
+    binhash: c0cf30efd9d806ae06abdd4f8745f203
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01005223
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005223
   hashes:
-    binhash: 83c81c67ec4c73e3b627658f157f9167
+    binhash: 748498066feb29db86d5cba034896f0e
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/stasets/X01010206
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01010206
   hashes:
-    binhash: 3cd192880dc588309b552c5afc6079a5
+    binhash: 8dd300f465eea227616db55ac49cce39
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/sulpc_oxidants_N96_L38
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:
-    binhash: e839a63e8dbfacb752b11b6e40acac91
+    binhash: 9c3311433135dc347fe097fc113655fb
     md5: 7c42d1faf74b2b9f6819f2349a8d0d25
 work/atmosphere/INPUT/vertlevs_G3:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/vertlevs_G3
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
   hashes:
-    binhash: da82de35191dc174c4c8e35d67c99bcd
+    binhash: 8e52dba88a7acf3282d8cd71ff78d927
     md5: 58ca02de69b16bd59771c81e06c4c21a
-work/atmosphere/INPUT/volcts_18502000ave.dat:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/atmosphere/volcts_18502000ave.dat
-  hashes:
-    binhash: 26c6ad3ebd1abb9a2ca01349a0666db3
-    md5: 47bd369c750be55d706ab60c78bc7aee
 work/atmosphere/INPUT/volcts_cmip6.dat:
-  fullpath: /g/data/access/payu/access-esm/input/historical/atmosphere/volcts_cmip6.dat
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
   hashes:
-    binhash: cb407b0f2ec8b82ef44d929fd0398589
+    binhash: 82272314b0d1690688617f3091d6d942
     md5: 9fa4ef9fbc7c86cebd22980e73347f67
 work/coupler/areas.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/areas.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
   hashes:
-    binhash: 39375018e6f2638b0cd7da8ec7c2420b
+    binhash: 4642ac951c28d9aa82b81bbbd867ae65
     md5: 1aac9e2f82d96176f7b87ba1efc8784e
-work/coupler/cf_name_table.txt:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/cf_name_table.txt
-  hashes:
-    binhash: 7b8129ade8835bb433bd09b1be3e57f0
-    md5: 74333d6fa3153ac294a74a506792375c
 work/coupler/grids.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/grids.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
   hashes:
-    binhash: ccc8568815e29aa1cb7ecb7048921fe3
+    binhash: 6738edbee8214fe8d6518b9a07648cd7
     md5: 2348de62f5fe4d55ec849f79e5d027fd
 work/coupler/masks.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/masks.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
   hashes:
-    binhash: 7efbc49f8af74ce19c919a1e7c2cb067
+    binhash: 54036576a2a3f905caed24309fb0c9c4
     md5: 0a12503901fd3d595bc25b5d3008f9d3
 work/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 5cc841b3f169f9d4505e906db881aeaa
+    binhash: 9009e3c6a194a031686751d376ff10a9
     md5: a8129dba5b3a7f70a5bc2fbf7f0e4f68
 work/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 31987aed0d1663a2accf622c45d48c13
+    binhash: 30c8809b10d8920ef12954aa0a325f52
     md5: 6fc856e7c2014e20903a01cdd61f4f2c
 work/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 77bd6be452e8540ac03fc045d912878f
+    binhash: f62cc68d9b137ccb555fa95ee48095d4
     md5: a2a7d940a9eaab59ec8fa49154116a64
 work/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
   hashes:
-    binhash: acb717d242d4f82235b7faf43dfe88f0
+    binhash: bdf67cd4a7e5c0d0a44928bbb98f782f
     md5: 25be6489585df07097d4b6009bf23ec2
 work/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 7c215f930059005b91587cb974080f73
+    binhash: e3ee9c792af4dff7ed90d1071e2915f3
     md5: 269086623444b48d0cd481e69d4bdc5f
 work/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: af03da7793772484a02e2013ed28efcb
+    binhash: 08a8baa1c8193888a047643c012ed308
     md5: 58ea836bf1e12d5fc21460763b02548f
 work/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 357efc2c164c5c7cb260a9c7646c3fda
+    binhash: 4eb008cfb0ecbdb2d656adf8f1fcad1d
     md5: 3bf9569f34b657f2ecab8ef5c93e7659
 work/ice/INPUT/grid.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/grid.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
   hashes:
-    binhash: b764d2a292522238386c3f8d0cee4abd
+    binhash: 6d68d12116e9a33c3a4f32697f2f9099
     md5: 1213e346055ee073fe33dc12578d99c6
 work/ice/INPUT/kmt.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/kmt.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
   hashes:
-    binhash: 0c877a77989a2a50c3917b1852b8042d
+    binhash: be194b251fc7cf066a7838c6d42d52c6
     md5: 2bde88b9e44c46aecf2ba2dff188d1ac
 work/ice/INPUT/monthly_sstsss.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ice/monthly_sstsss.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
   hashes:
-    binhash: 6cac7cb81fb3e2f38d580f5af18c8662
+    binhash: b9627932b4a9a2b27b9222aff3c34b3e
     md5: 323d4c605f83f4d7d3126da70153c2ed
-work/ocean/INPUT/basin_mask.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/basin_mask.nc
-  hashes:
-    binhash: d5db4dd513ea6f22d575704a92742e6e
-    md5: 20fd8740f24ca95c7c086343077e9c0d
 work/ocean/INPUT/bgc_param.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/bgc_param.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
   hashes:
-    binhash: 2323d53f5fa3939caafac559b7841315
-    md5: 7162c91ab9399c7a225fcb03593843ee
-work/ocean/INPUT/cfc_auscom.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/cfc_auscom.nc
-  hashes:
-    binhash: c79c317809fd33abb79a40ab03446b89
-    md5: 38660c8a5de3e3b63d2ae7ba5020d515
-work/ocean/INPUT/co2_obs.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/co2_obs.nc
-  hashes:
-    binhash: ee0bb372c1bfaceae7d1ed9fdf904137
-    md5: bfc3011737ab384d770b937b269e50fc
+    binhash: 782a2eb4284e5f9957808cde8c2caa32
+    md5: 9defb35e7a7181e9170a6ae57a4d3348
 work/ocean/INPUT/dust.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/dust.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
   hashes:
-    binhash: ea10d318b8919f3de2c6126bc050178f
+    binhash: 49a75ca8afd73304a2b6503a8d4e2c8d
     md5: bfbbea8ac46a932d0ec8631afbfc2ae2
-work/ocean/INPUT/geothermal_heating.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/geothermal_heating.nc
-  hashes:
-    binhash: 3eaf6b5c2d2cb6ecb28a4f7b2329283d
-    md5: 381cb231d8d059576adca0c2bea9c030
 work/ocean/INPUT/grid_spec.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/grid_spec.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
   hashes:
-    binhash: 24c438668010498f4c85736ff1f42920
+    binhash: f1a888b759f58109498d84a49d38755e
     md5: b9adc1e552201aa3abc6efb72786ec93
-work/ocean/INPUT/ocmip2_abiotic_c14_atm_hist_om3_bc-1-9999.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_abiotic_c14_atm_hist_om3_bc-1-9999.nc
-  hashes:
-    binhash: d3f0efeb24fc0d94bc87e4324d494fe3
-    md5: e91a04235ab63ef060d0c6e350ed9581
 work/ocean/INPUT/ocmip2_fice_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_fice_monthly_om1p5_bc.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
   hashes:
-    binhash: 211ad76fa96e19ac6d7a631fa36ed6bd
+    binhash: e2df4b9f082ee328d641c654e3645ba3
     md5: c0ed75eef44962dbe6fc9f61dbd228a9
 work/ocean/INPUT/ocmip2_press_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_press_monthly_om1p5_bc.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
   hashes:
-    binhash: f37b73ef4aab8c78364b8565657228fb
+    binhash: 5611c718222eb398adb60c3e79345cd1
     md5: 2e71cbb78c052e06e3df20f862928da2
-work/ocean/INPUT/ocmip2_siple_co2_atm_am2_bc-1-9999.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_siple_co2_atm_am2_bc-1-9999.nc
-  hashes:
-    binhash: 754c5309b1dab13e4181ae1267091bc7
-    md5: bf1db4228eeacb676da968073b8c5848
 work/ocean/INPUT/ocmip2_xkw_monthly_om1p5_bc.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/pre-industrial/ocmip2_xkw_monthly_om1p5_bc.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
   hashes:
-    binhash: e8a7cae4dd9b7df46506b745159e32f9
+    binhash: 1bd60fbe64d79db886cb57e8bf0b0fba
     md5: 348a035bed83e280bb0a1de0066947fc
 work/ocean/INPUT/roughness_amp.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/roughness_amp.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
   hashes:
-    binhash: fa99351a0db4c3600beb3493f3457473
+    binhash: 485ca6a5fbf5c1d359aac56f9faa3745
     md5: 185dadeb53da2de75b47c53fd7085f89
 work/ocean/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/ssw_atten_depth.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
   hashes:
-    binhash: d418c8d266bfd03aee41f5e863acf1fb
+    binhash: 6d3800b1f4037959b9e11983b23d623b
     md5: 3e88b51db135788aa4348d58cbeabfad
 work/ocean/INPUT/tideamp.nc:
-  fullpath: /g/data/access/payu/access-esm/input/pre-industrial/ocean/common/tideamp.nc
+  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
   hashes:
-    binhash: 383e61184c0b3dd57c35ee408a6ce531
+    binhash: 7554b910b770fa44a3b2124697d9596d
     md5: b2840af757d9b7b40207f33f1fc84c5c

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -2,352 +2,352 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/INPUT/BC_hi_1849_2015_ESM1.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/BC_hi_1849_2015_ESM1.anc
   hashes:
-    binhash: 4f5918628037f3bc105ff728e88743e1
+    binhash: 77ecb24ca0aada9ea3871fa17eb9ffc9
     md5: f16cdb65e5d35103b1d7b7f45abcfffa
 work/atmosphere/INPUT/Bio_1849_2015_ESM1.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/Bio_1849_2015_ESM1.anc
   hashes:
-    binhash: 8261c44d3d173d0aa146879d8c84b377
+    binhash: 3d1bbeea23f49ee75e7cc9c0f41c9db5
     md5: fb650ff10a39596b92f67b1393c15289
 work/atmosphere/INPUT/DMS_conc.N96:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/DMS_conc.N96
   hashes:
-    binhash: 1dbda8c60c4d62ef45f7e16f95a0ed5e
+    binhash: da1baa25e78ec281c82ea4588e30a340
     md5: 7e8ec8de832c0b9b8c1d9f0eda4d54e5
 work/atmosphere/INPUT/Ndep_1849_2015.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/land/biogeochemistry/global.N96/2021.06.22/Ndep_1849_2015.anc
   hashes:
-    binhash: 9cc466ac85225df7b8cac75dbe75eef2
+    binhash: 70379cea8570223286b661347b720b39
     md5: ff75533e9f52d92c42ac3556b4ec1fed
 work/atmosphere/INPUT/OCFF_1849_2015_ESM1.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/OCFF_1849_2015_ESM1.anc
   hashes:
-    binhash: 8254af51276a6bb45ff29676a3350903
+    binhash: c80d56183157d220322253672fc9198b
     md5: 1e38cac3a03101fb5aa5d88c713e809c
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
   hashes:
-    binhash: d3920a828b9e688d1f8a3e0072b0966c
+    binhash: 4f75001536d84c87362b607aa42c4f61
     md5: 74cbbb76edfbd9f7c4b928609c00cd64
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A.original:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
   hashes:
-    binhash: 71f58a61a27ec726505e4c6ef856015e
+    binhash: c7d3efdc2ca645724064afc4f7e655f6
     md5: ed1004d9aca8d29baba143ea12defbb7
 work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
   hashes:
-    binhash: 4c543a1a96f8c9ad683cb727392b628e
+    binhash: 763bf187687a18a505264b4b79d40153
     md5: 5a65d77c62d55e3b62e35ad9662d32a9
 work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
   hashes:
-    binhash: e30f11b2cc9986c9d35df2444eeb5f6d
+    binhash: 6d6eb7e1e0f21e635e532202f7b8d462
     md5: 85ff5d563968cf24d1be595b05b4e52d
 work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
   hashes:
-    binhash: fe4b17e09dc200e53201c6f70df45e91
+    binhash: 919a2c8987bd593c78153ff323efeb51
     md5: 1e4391ea1f6234b33c33168bd7089d06
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
   hashes:
-    binhash: d7d9659dc6992445154811f780f2836e
+    binhash: 9401083e4199439b77254fc490b6597d
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/TSI_CMIP6_ESM_v2:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
   hashes:
-    binhash: 468a1106268925cd9d80f6a21eabafdd
+    binhash: 32f787c9ffdf8902cf642fe218ff76d5
     md5: 15aa13632aa616dcf079b152a5cbd120
 work/atmosphere/INPUT/biogenic_351sm.N96L38:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/biogenic_351sm.N96L38
   hashes:
-    binhash: 49e0bea671cc17c479424e81e77b3aca
+    binhash: 35f8585c3290dfc25ed19e7d93f6a1bb
     md5: 55eb75f602a4639fb3c8ff40e36eb661
 work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/land/vegetation/global.N96/2024.07.04/cableCMIP6_LC_1850-2015.nc
   hashes:
-    binhash: 397842d5ac8f889e9144cba9b72588a9
+    binhash: fc03d315746c6a0b254a7632dc28295c
     md5: 78ddfbdc9d9551cf6c6c39fe734716a4
 work/atmosphere/INPUT/cable_vegfunc_N96.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/vegetation/global.N96/2020.05.19/cable_vegfunc_N96.anc
   hashes:
-    binhash: 99bd59c0f007fc09f5621ee56310d00a
+    binhash: b590c62f20575a65f1f5ee83ec687304
     md5: 7a8cb16191ad29b081514657893530c6
 work/atmosphere/INPUT/def_soil_params.txt:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_soil_params.txt
   hashes:
-    binhash: 2e9e0346384f9e6616e5f76b000a1450
+    binhash: f6bbe84fb16971f00d2ba34eef542976
     md5: 93107e8c37e04ccf97471fd2ac8f63eb
 work/atmosphere/INPUT/def_veg_params.txt:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeophysics/resolution_independent/2020.05.19/def_veg_params.txt
   hashes:
-    binhash: b431e3cba0955aff93a49fe91bcd4b41
+    binhash: 22ce1f400a832868aefeaa9721ac3a48
     md5: 1f9a27f0e252bf6c466100573c126789
 work/atmosphere/INPUT/modis_phenology_csiro.txt:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/modis_phenology_csiro.txt
   hashes:
-    binhash: cd935a21abd6aace04b4ac6ea11f2f2a
+    binhash: a86ffb366359d6d353c6f385789185a1
     md5: a7b89d25cff82cf13cf812a98ad3a029
 work/atmosphere/INPUT/ozone_1849_2015_ESM1.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/global.N96/2021.06.22/ozone_1849_2015_ESM1.anc
   hashes:
-    binhash: 22ffb9928874dc5bfcd35b813bdd9154
+    binhash: d0f4f5fa148594a325854548f84b82eb
     md5: b85f5374d1b89cf23cff05b6c35c4d0f
 work/atmosphere/INPUT/pftlookup_csiro_v16_17tiles_wtlnds.csv:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/land/biogeochemistry/resolution_independent/2020.05.19/pftlookup_csiro_v16_17tiles_wtlnds.csv
   hashes:
-    binhash: b9625a4309cd3c6f9f0b7cfb685b1a5d
+    binhash: 7b29e253f569372abb0a5f2769b58a3d
     md5: 109d0702afd2cb0a66bf141faccaee30
 work/atmosphere/INPUT/qrparm.mask:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/grids/global.N96/2020.05.19/qrparm.mask
   hashes:
-    binhash: 7fae36d3285eef1c799467116c4982a1
+    binhash: 6d189a763e3418d2cf61581eded5522e
     md5: f497c7827bd22ef0b98f1d1af776866d
 work/atmosphere/INPUT/qrparm.soil_igbp_vg:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/land/soiltype/global.N96/2020.05.19/qrparm.soil_igbp_vg
   hashes:
-    binhash: 413eef63cfad90a94c0216157f4880cd
+    binhash: 51560dde970f7123a7250cc6bdc8f3ef
     md5: 26ce57f462dd574fe49f290ab7877112
 work/atmosphere/INPUT/scycl_1849_2015_ESM1_v4.anc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/aerosol/global.N96/2021.06.22/scycl_1849_2015_ESM1_v4.anc
   hashes:
-    binhash: 3cbf9138c2ffb3e62582df1c6ef9acc4
+    binhash: aa9156fbc9be897ba7e9f32ad0b267e3
     md5: 66ef33e0d38eb1a9f550766c1952a252
 work/atmosphere/INPUT/spec3a_lw_hadgem1_6on:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_lw_hadgem1_6on
   hashes:
-    binhash: 71592073489ce511f5b22629f3797195
+    binhash: 278569974348c9583fe0a2a9e1828ffd
     md5: 9ff85916dbb36ba6679b954d16387aee
 work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/spectral/resolution_independent/2020.05.19/spec3a_sw_hadgem1_6on
   hashes:
-    binhash: cc5a36a0f0729bc07907f8dbcf493ce7
+    binhash: 149899ecc54ed754ab8c6f05cb99f140
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01001218
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01001218
   hashes:
-    binhash: eb961fc8eccd9a11c566abdff83e114a
+    binhash: cef321aa4d4eeae2d156db854ce276c4
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01002207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01002207
   hashes:
-    binhash: adb2608485efd33ee99d9edc47d8bf9c
+    binhash: 4e7a1dc7a52a0aab1da67b9328510fb5
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003236
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003236
   hashes:
-    binhash: 0c9907a1bd062dea7ae253ec005ab745
+    binhash: 5cdf6aea7e61410df48d3cac8469454d
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003237
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003237
   hashes:
-    binhash: 2ffdc2d4dc0436f10a359579a8aaae1e
+    binhash: 883c4ddd6d137ac441bf6c045c8a1c39
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003254
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003254
   hashes:
-    binhash: b86c9c0ba28c227326fc327ae729c823
+    binhash: e6db920da74cdf06c3c32053d778e9f3
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003255
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003255
   hashes:
-    binhash: 85db3e92f317067af18366ff4d64aa6c
+    binhash: 9b804470b184c2e3a143a64314b4baf3
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003274
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003274
   hashes:
-    binhash: 20801e04d6ff34e95f50c1151b95c774
+    binhash: a999c69b36a2f7d183e8b9fce0b17dba
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003275
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003275
   hashes:
-    binhash: 2e08890e974c76d7c3861ea746a28d46
+    binhash: 24c47dd90d0a17b6fa81e48133f310e3
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003276
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003276
   hashes:
-    binhash: 1b25673ce03da78d46a3bac4e4ad7b91
+    binhash: 9c8d8aa71ac65ee098ac3a50f00007c3
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003277
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003277
   hashes:
-    binhash: ef28c2a6c67440e3eba2defe59e97ca7
+    binhash: da58ccbd06fe6cf6987f8eef37590c70
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003278
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003278
   hashes:
-    binhash: 1400c2b251d2b318fc23984566ce11bd
+    binhash: 5a899ad334e42cc3cdd1ab14429299ed
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003279
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003279
   hashes:
-    binhash: e28e57094a8024634b11f9af265d9574
+    binhash: a43fcc064f100a634326d53110ab8fe2
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003280
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003280
   hashes:
-    binhash: dbe15584ea0e14110d3cffc70822ef24
+    binhash: 05b3ac5c90fdf71e906e3b6e0dcf3329
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003281
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003281
   hashes:
-    binhash: db854998561a42f136d1ff0a93e005d2
+    binhash: 990649b208fa059df477aef96d2242a0
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01003286
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003286
   hashes:
-    binhash: 25865182a2ef2258f9265b6787466f0a
+    binhash: 731b64153656addbd7bd29b98e60906a
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005207
   hashes:
-    binhash: e906a4633db2e7081ca7290df98220ae
+    binhash: 52ae55398cdcdf5582bd6253755c5185
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005208
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005208
   hashes:
-    binhash: a8a0cbbc62ab03db040a81ed5846db9f
+    binhash: 4d114e56511e247ca65b4bd79cd66437
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005222
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005222
   hashes:
-    binhash: c0cf30efd9d806ae06abdd4f8745f203
+    binhash: 115879288e4fe41cf3aa936793597f0a
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01005223
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005223
   hashes:
-    binhash: 748498066feb29db86d5cba034896f0e
+    binhash: b0707253914846f3a526030c52a818fe
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/stash/2020.05.19/stasets/X01010206
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01010206
   hashes:
-    binhash: 8dd300f465eea227616db55ac49cce39
+    binhash: a7c6cf46b049f520547eab48654687ad
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:
-    binhash: 9c3311433135dc347fe097fc113655fb
+    binhash: e8b31e6ca1af7da756d87243e622e3c8
     md5: 7c42d1faf74b2b9f6819f2349a8d0d25
 work/atmosphere/INPUT/vertlevs_G3:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/grids/resolution_independent/2020.05.19/vertlevs_G3
   hashes:
-    binhash: 8e52dba88a7acf3282d8cd71ff78d927
+    binhash: 67eeeb98a7de5eee305f026a20482cc7
     md5: 58ca02de69b16bd59771c81e06c4c21a
 work/atmosphere/INPUT/volcts_cmip6.dat:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/volcts_cmip6.dat
   hashes:
-    binhash: 82272314b0d1690688617f3091d6d942
+    binhash: a041386af6706dc7cb9e96816bf8f234
     md5: 9fa4ef9fbc7c86cebd22980e73347f67
 work/coupler/areas.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/areas.nc
   hashes:
-    binhash: 4642ac951c28d9aa82b81bbbd867ae65
+    binhash: 74a0105eb80df5993bef82be279536ee
     md5: 1aac9e2f82d96176f7b87ba1efc8784e
 work/coupler/grids.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/grids.nc
   hashes:
-    binhash: 6738edbee8214fe8d6518b9a07648cd7
+    binhash: dd60e450879fe3d1bc8697179b2bb68e
     md5: 2348de62f5fe4d55ec849f79e5d027fd
 work/coupler/masks.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/grids/global.oi_1deg.a_N96/2020.05.19/masks.nc
   hashes:
-    binhash: 54036576a2a3f905caed24309fb0c9c4
+    binhash: 9372991dd00c8f0d9a2aeb97fb36d1f1
     md5: 0a12503901fd3d595bc25b5d3008f9d3
 work/coupler/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1t_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 9009e3c6a194a031686751d376ff10a9
+    binhash: 10999c39f61114a78b187ec0f98cd3f6
     md5: a8129dba5b3a7f70a5bc2fbf7f0e4f68
 work/coupler/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1u_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 30c8809b10d8920ef12954aa0a325f52
+    binhash: 1d0f36698633414416f8e744c88e2746
     md5: 6fc856e7c2014e20903a01cdd61f4f2c
 work/coupler/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_cice_to_um1v_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: f62cc68d9b137ccb555fa95ee48095d4
+    binhash: 059755d03c22fc3f8d05af551a2f8efb
     md5: a2a7d940a9eaab59ec8fa49154116a64
 work/coupler/rmp_um1t_to_cice_CONSERV_DESTAREA.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_DESTAREA.nc
   hashes:
-    binhash: bdf67cd4a7e5c0d0a44928bbb98f782f
+    binhash: 32ae62df22794a672138d9b1e4f78dd5
     md5: 25be6489585df07097d4b6009bf23ec2
 work/coupler/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1t_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: e3ee9c792af4dff7ed90d1071e2915f3
+    binhash: 79c6f6f8817db2cf95dc815fcd84bc3f
     md5: 269086623444b48d0cd481e69d4bdc5f
 work/coupler/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1u_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 08a8baa1c8193888a047643c012ed308
+    binhash: 130343da4a880b8d9f3e210eec37a556
     md5: 58ea836bf1e12d5fc21460763b02548f
 work/coupler/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/coupler/remapping_weights/global.oi_1deg.a_N96/2020.05.19/rmp_um1v_to_cice_CONSERV_FRACNNEI.nc
   hashes:
-    binhash: 4eb008cfb0ecbdb2d656adf8f1fcad1d
+    binhash: 89de238897ba6f06a4c9a1bcefe4ebc8
     md5: 3bf9569f34b657f2ecab8ef5c93e7659
 work/ice/INPUT/grid.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/grid.nc
   hashes:
-    binhash: 6d68d12116e9a33c3a4f32697f2f9099
+    binhash: e27f1045f956550305426c6abb36c868
     md5: 1213e346055ee073fe33dc12578d99c6
 work/ice/INPUT/kmt.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/grids/global.1deg/2020.05.19/kmt.nc
   hashes:
-    binhash: be194b251fc7cf066a7838c6d42d52c6
+    binhash: 0ed504b151b168eebdee3aa13edd8c37
     md5: 2bde88b9e44c46aecf2ba2dff188d1ac
 work/ice/INPUT/monthly_sstsss.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ice/climatology/global.1deg/2020.05.19/monthly_sstsss.nc
   hashes:
-    binhash: b9627932b4a9a2b27b9222aff3c34b3e
+    binhash: 49aab10f25c58a9a0ffa5617847050ff
     md5: 323d4c605f83f4d7d3126da70153c2ed
 work/ocean/INPUT/bgc_param.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
   hashes:
-    binhash: 782a2eb4284e5f9957808cde8c2caa32
+    binhash: 69340d523fddf842e3e7a030eb139111
     md5: 9defb35e7a7181e9170a6ae57a4d3348
 work/ocean/INPUT/dust.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
   hashes:
-    binhash: 49a75ca8afd73304a2b6503a8d4e2c8d
+    binhash: 89983106fff4813c347b2e98a8f62f52
     md5: bfbbea8ac46a932d0ec8631afbfc2ae2
 work/ocean/INPUT/grid_spec.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
   hashes:
-    binhash: f1a888b759f58109498d84a49d38755e
+    binhash: 20468cf509d14ec15c908f7fbd8b3de5
     md5: b9adc1e552201aa3abc6efb72786ec93
 work/ocean/INPUT/ocmip2_fice_monthly_om1p5_bc.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
   hashes:
-    binhash: e2df4b9f082ee328d641c654e3645ba3
+    binhash: 60f4723017d75ebe8a5bc5fe0f37ad1d
     md5: c0ed75eef44962dbe6fc9f61dbd228a9
 work/ocean/INPUT/ocmip2_press_monthly_om1p5_bc.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
   hashes:
-    binhash: 5611c718222eb398adb60c3e79345cd1
+    binhash: d4b3605e8765d477b02a55d6ae21feac
     md5: 2e71cbb78c052e06e3df20f862928da2
 work/ocean/INPUT/ocmip2_xkw_monthly_om1p5_bc.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
   hashes:
-    binhash: 1bd60fbe64d79db886cb57e8bf0b0fba
+    binhash: 39f04199eedf0e3a6c638d890795311e
     md5: 348a035bed83e280bb0a1de0066947fc
 work/ocean/INPUT/roughness_amp.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
   hashes:
-    binhash: 485ca6a5fbf5c1d359aac56f9faa3745
+    binhash: 9283cb9b6093d7d9570797f360062d10
     md5: 185dadeb53da2de75b47c53fd7085f89
 work/ocean/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
   hashes:
-    binhash: 6d3800b1f4037959b9e11983b23d623b
+    binhash: 4a66b77be6d419706657e3fe3e5bf210
     md5: 3e88b51db135788aa4348d58cbeabfad
 work/ocean/INPUT/tideamp.nc:
-  fullpath: /g/data/tm70/sw6175/esm1p5-input-restructure/restructured-inputs/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
   hashes:
-    binhash: 7554b910b770fa44a3b2124697d9596d
+    binhash: f20fffd2f2b42e73b177b439b006751d
     md5: b2840af757d9b7b40207f33f1fc84c5c

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -2,172 +2,172 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/README:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/README
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/atmosphere/README
   hashes:
-    binhash: 146623fe0f40a5ece41a5e910b8bbc71
+    binhash: f57a720728dd5c5b853f8e987643e7ce
     md5: 7bd64f211428cf0756fc965d7b443501
 work/atmosphere/restart_dump.astart:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/restart_dump.astart
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/atmosphere/restart_dump.astart
   hashes:
-    binhash: 40840e456a0a185c6c024a41ae5894f5
+    binhash: 7fe3b6a871a05ae7e5e8b911fdcdbf40
     md5: c46e4c9265692579cdca359972bfd3d4
 work/atmosphere/um.res.yaml:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/um.res.yaml
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/atmosphere/um.res.yaml
   hashes:
-    binhash: e2a03fe73fc152786b82ce81ca9fb6cb
+    binhash: a53dd6afbe78e47493e06f8be0bd85fa
     md5: 78f26c60a2e2e0336c7acec9bfecd7bf
 work/coupler/README:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/README
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/coupler/README
   hashes:
-    binhash: 835fad6816c20e1edcee626a95ff11f1
+    binhash: 3388804d2dae44197e0fde01495629db
     md5: 768ff92e08cd282933f69084ca3d18d2
 work/coupler/a2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/a2i.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/coupler/a2i.nc
   hashes:
-    binhash: cc918deb217394f76b4d1e2e42cee78a
+    binhash: b8437c85bbc29062081226eae5fb978e
     md5: 53c917f70f867e37a084672e8a1997db
 work/coupler/i2a.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/i2a.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/coupler/i2a.nc
   hashes:
-    binhash: 5615e4a335f656d8b2f1a5445a571079
+    binhash: 9990cd434a4afbb180bdd0c32fb03020
     md5: a30b12d2709ef6ae6bb40444b1db0ee2
 work/coupler/o2i.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/o2i.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/coupler/o2i.nc
   hashes:
-    binhash: e1441078554929b3048f6c1639442834
+    binhash: d9763a791d85ca3e6f5d72df38dd4f17
     md5: 66a4bed2d785d04bf9041e14eb15d87f
 work/ice/RESTART/README:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/README
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/README
   hashes:
-    binhash: 775d1b7f9575d64b0155d52492700b8d
+    binhash: f57a720728dd5c5b853f8e987643e7ce
     md5: 7bd64f211428cf0756fc965d7b443501
 work/ice/RESTART/cice_in.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/cice_in.nml
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/cice_in.nml
   hashes:
-    binhash: b4a841c60032411da64c47ebaaed5a54
+    binhash: 964ce13887127b0fca33694842cfe245
     md5: 1576287c82da88ffc4752430100f848e
 work/ice/RESTART/ice.restart_file:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/ice.restart_file
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/ice.restart_file
   hashes:
-    binhash: 70c3f0a73b33a905327c06a70564e9f2
+    binhash: 1786d94c4f19ac949de1e7bd1fd9f236
     md5: 507c36763937f8f47d5a592c5d24095d
 work/ice/RESTART/iced.18500101:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/iced.18500101
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/iced.18500101
   hashes:
-    binhash: 672eaee521b97b4c79121320fb7a2098
+    binhash: 634b078d50fc548419b4d35d1c07e8d5
     md5: ca0d4395cfadb19a9b0ab4d07bd25961
 work/ice/RESTART/input_ice.nml:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/input_ice.nml
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/input_ice.nml
   hashes:
-    binhash: 2d36bfecd6d26ce998bf74e7e38be372
+    binhash: c0a592b8720ecff569b5ba9558d38f03
     md5: 48d62b9cbf71fe6373c02005adb58471
 work/ice/RESTART/mice.nc:
   copy: true
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/mice.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ice/mice.nc
   hashes:
-    binhash: 255d18ea8c7268fd644843d3e6bf6dd0
+    binhash: 24ce8602876ab14e9607f4d4ed192f44
     md5: 0085475b82f3e0876b7be9203538c97a
 work/ocean/INPUT/README:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/README
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/README
   hashes:
-    binhash: 1a318e5d404b041939b1b2e6cbb1d89d
+    binhash: 814bf75a649faefd86bf05204f5716a3
     md5: 768ff92e08cd282933f69084ca3d18d2
 work/ocean/INPUT/csiro_bgc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc.res.nc
   hashes:
-    binhash: 33db9151a621ba1dde38def2d4bd9436
+    binhash: 9df75dc4846b643bc6df4db15bbd5f18
     md5: 0567fdf6be0e1f7da67e3f7aed3e32c0
 work/ocean/INPUT/csiro_bgc_sediment.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc_sediment.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc_sediment.res.nc
   hashes:
-    binhash: c782af938c069c96c34b8440a79ee7c0
+    binhash: 114b137685fafde1782498e315c94ca6
     md5: d1de12ab9eef3a4ba17113a801f9e6f8
 work/ocean/INPUT/ocean_age.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_age.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_age.res.nc
   hashes:
-    binhash: df431ebdef63a7b911d661e9079f01b9
+    binhash: acc7cafdd3d693816054a945b1d957cc
     md5: b324bd43e343d2b8eb3bd5d9014e1dba
 work/ocean/INPUT/ocean_barotropic.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_barotropic.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_barotropic.res.nc
   hashes:
-    binhash: 8c79d9693598c2616a4ce6f73cfc40e6
+    binhash: ee3a20c3240d65ff567338490e796c8f
     md5: 2c65c22e627689dbb99c7e48d198eec6
 work/ocean/INPUT/ocean_bih_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_bih_friction.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_bih_friction.res.nc
   hashes:
-    binhash: 601e0b4b44c435e3c824f16be5650ab0
+    binhash: 3c6788d9d210e103c370f611fbdbadc6
     md5: 6cc40c8d7895bc9bf8d14066e5aa1fbd
 work/ocean/INPUT/ocean_density.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_density.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_density.res.nc
   hashes:
-    binhash: 043d86f986a41df8905256086b96a88c
+    binhash: 678f0a30336ab556c2472ef8daa1b28e
     md5: 07cdb0236d303b767ee6fb75ced59785
 work/ocean/INPUT/ocean_frazil.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_frazil.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_frazil.res.nc
   hashes:
-    binhash: b3d867e9362dfff54c19509330b10572
+    binhash: eaf2f2a95d5d1640868c2990d30ac21e
     md5: b6feb3d546146172f7d877f259f412a6
 work/ocean/INPUT/ocean_lap_friction.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_lap_friction.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_lap_friction.res.nc
   hashes:
-    binhash: 086b70318475372bc270028f3f06e579
+    binhash: 5407de8b34be3f04cbdeba978699f3f8
     md5: d2c9747a6a51b6edc4e7474b5e424bb3
 work/ocean/INPUT/ocean_neutral.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_neutral.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_neutral.res.nc
   hashes:
-    binhash: 148ffc05cf45b876c13186babd5b146b
+    binhash: 5c867ea3a0c80623b069ccaadb44d4fe
     md5: ada60736c5cda5f230e0e57cc074f08b
 work/ocean/INPUT/ocean_pot_temp.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_pot_temp.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_pot_temp.res.nc
   hashes:
-    binhash: f71ca7728a40180c3869fdf2a15cb453
+    binhash: 53983b268dbdd9afa6b7d0d3c4db78be
     md5: f4f55e359da62c16c93bc2b394eb57e1
 work/ocean/INPUT/ocean_sbc.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sbc.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sbc.res.nc
   hashes:
-    binhash: 3b7922dc1709fe7d1e30089dbb25c121
+    binhash: c75e2132ab7182f31f50007ec50ffd16
     md5: 329c77b819420ef9f878fef98818b9bf
 work/ocean/INPUT/ocean_sigma_transport.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sigma_transport.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sigma_transport.res.nc
   hashes:
-    binhash: 46bd711ba06ad8c98c51060336ad4c79
+    binhash: 4cc6be89635699811f819cb04ef174a2
     md5: fe527a9917d30955d0dc082271c1392f
 work/ocean/INPUT/ocean_solo.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_solo.res
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_solo.res
   hashes:
-    binhash: 6d93d239ade592f4325ce3a79102eed2
+    binhash: 3ae0ee4bddf19bb7120ed54353a1f53a
     md5: 2b1c789b3ff6389a05a769a0d0934334
 work/ocean/INPUT/ocean_temp_salt.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_temp_salt.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_temp_salt.res.nc
   hashes:
-    binhash: 5a4781cfb2b3e602fe708431e89727bf
+    binhash: d2dede6c32380e06180101a5c8fe648b
     md5: d59017739edb08299afe542567f73095
 work/ocean/INPUT/ocean_thickness.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_thickness.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_thickness.res.nc
   hashes:
-    binhash: da6a5690d12f13a967098db7e56bdba1
+    binhash: 162389752d182dbf18c5137b9acfa923
     md5: 67be2b864dcb5e643aa2b80ae44e78ca
 work/ocean/INPUT/ocean_tracer.res:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_tracer.res
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_tracer.res
   hashes:
-    binhash: 273e80558f0528c2c5d351b8c168f1b1
+    binhash: 2629e16aa1c6541121c84b78c47b470b
     md5: 4d105dfe1fba502278db9e80d5ec1dae
 work/ocean/INPUT/ocean_velocity.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity.res.nc
   hashes:
-    binhash: 94b128539f24f252dfe03d6a8c3e7f64
+    binhash: 25375d5efe4247f5af0e7b81e46b864b
     md5: bc927019d11866a8ae67cb5bd5ddec93
 work/ocean/INPUT/ocean_velocity_advection.res.nc:
-  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity_advection.res.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity_advection.res.nc
   hashes:
-    binhash: 03d9e461c0eab0d3d4f5a375fd84237a
+    binhash: 835cb1239595d73d8839aabbf9e330dd
     md5: 2183be2ef353d129f56688247b0fbf3d

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -1,0 +1,173 @@
+format: yamanifest
+version: 1.0
+---
+work/atmosphere/README:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/README
+  hashes:
+    binhash: 146623fe0f40a5ece41a5e910b8bbc71
+    md5: 7bd64f211428cf0756fc965d7b443501
+work/atmosphere/restart_dump.astart:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/restart_dump.astart
+  hashes:
+    binhash: 40840e456a0a185c6c024a41ae5894f5
+    md5: c46e4c9265692579cdca359972bfd3d4
+work/atmosphere/um.res.yaml:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/atmosphere/um.res.yaml
+  hashes:
+    binhash: e2a03fe73fc152786b82ce81ca9fb6cb
+    md5: 78f26c60a2e2e0336c7acec9bfecd7bf
+work/coupler/README:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/README
+  hashes:
+    binhash: 835fad6816c20e1edcee626a95ff11f1
+    md5: 768ff92e08cd282933f69084ca3d18d2
+work/coupler/a2i.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/a2i.nc
+  hashes:
+    binhash: cc918deb217394f76b4d1e2e42cee78a
+    md5: 53c917f70f867e37a084672e8a1997db
+work/coupler/i2a.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/i2a.nc
+  hashes:
+    binhash: 5615e4a335f656d8b2f1a5445a571079
+    md5: a30b12d2709ef6ae6bb40444b1db0ee2
+work/coupler/o2i.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/coupler/o2i.nc
+  hashes:
+    binhash: e1441078554929b3048f6c1639442834
+    md5: 66a4bed2d785d04bf9041e14eb15d87f
+work/ice/RESTART/README:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/README
+  hashes:
+    binhash: 775d1b7f9575d64b0155d52492700b8d
+    md5: 7bd64f211428cf0756fc965d7b443501
+work/ice/RESTART/cice_in.nml:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/cice_in.nml
+  hashes:
+    binhash: b4a841c60032411da64c47ebaaed5a54
+    md5: 1576287c82da88ffc4752430100f848e
+work/ice/RESTART/ice.restart_file:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/ice.restart_file
+  hashes:
+    binhash: 70c3f0a73b33a905327c06a70564e9f2
+    md5: 507c36763937f8f47d5a592c5d24095d
+work/ice/RESTART/iced.18500101:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/iced.18500101
+  hashes:
+    binhash: 672eaee521b97b4c79121320fb7a2098
+    md5: ca0d4395cfadb19a9b0ab4d07bd25961
+work/ice/RESTART/input_ice.nml:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/input_ice.nml
+  hashes:
+    binhash: 2d36bfecd6d26ce998bf74e7e38be372
+    md5: 48d62b9cbf71fe6373c02005adb58471
+work/ice/RESTART/mice.nc:
+  copy: true
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ice/mice.nc
+  hashes:
+    binhash: 255d18ea8c7268fd644843d3e6bf6dd0
+    md5: 0085475b82f3e0876b7be9203538c97a
+work/ocean/INPUT/README:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/README
+  hashes:
+    binhash: 1a318e5d404b041939b1b2e6cbb1d89d
+    md5: 768ff92e08cd282933f69084ca3d18d2
+work/ocean/INPUT/csiro_bgc.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc.res.nc
+  hashes:
+    binhash: 33db9151a621ba1dde38def2d4bd9436
+    md5: 0567fdf6be0e1f7da67e3f7aed3e32c0
+work/ocean/INPUT/csiro_bgc_sediment.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/csiro_bgc_sediment.res.nc
+  hashes:
+    binhash: c782af938c069c96c34b8440a79ee7c0
+    md5: d1de12ab9eef3a4ba17113a801f9e6f8
+work/ocean/INPUT/ocean_age.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_age.res.nc
+  hashes:
+    binhash: df431ebdef63a7b911d661e9079f01b9
+    md5: b324bd43e343d2b8eb3bd5d9014e1dba
+work/ocean/INPUT/ocean_barotropic.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_barotropic.res.nc
+  hashes:
+    binhash: 8c79d9693598c2616a4ce6f73cfc40e6
+    md5: 2c65c22e627689dbb99c7e48d198eec6
+work/ocean/INPUT/ocean_bih_friction.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_bih_friction.res.nc
+  hashes:
+    binhash: 601e0b4b44c435e3c824f16be5650ab0
+    md5: 6cc40c8d7895bc9bf8d14066e5aa1fbd
+work/ocean/INPUT/ocean_density.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_density.res.nc
+  hashes:
+    binhash: 043d86f986a41df8905256086b96a88c
+    md5: 07cdb0236d303b767ee6fb75ced59785
+work/ocean/INPUT/ocean_frazil.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_frazil.res.nc
+  hashes:
+    binhash: b3d867e9362dfff54c19509330b10572
+    md5: b6feb3d546146172f7d877f259f412a6
+work/ocean/INPUT/ocean_lap_friction.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_lap_friction.res.nc
+  hashes:
+    binhash: 086b70318475372bc270028f3f06e579
+    md5: d2c9747a6a51b6edc4e7474b5e424bb3
+work/ocean/INPUT/ocean_neutral.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_neutral.res.nc
+  hashes:
+    binhash: 148ffc05cf45b876c13186babd5b146b
+    md5: ada60736c5cda5f230e0e57cc074f08b
+work/ocean/INPUT/ocean_pot_temp.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_pot_temp.res.nc
+  hashes:
+    binhash: f71ca7728a40180c3869fdf2a15cb453
+    md5: f4f55e359da62c16c93bc2b394eb57e1
+work/ocean/INPUT/ocean_sbc.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sbc.res.nc
+  hashes:
+    binhash: 3b7922dc1709fe7d1e30089dbb25c121
+    md5: 329c77b819420ef9f878fef98818b9bf
+work/ocean/INPUT/ocean_sigma_transport.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_sigma_transport.res.nc
+  hashes:
+    binhash: 46bd711ba06ad8c98c51060336ad4c79
+    md5: fe527a9917d30955d0dc082271c1392f
+work/ocean/INPUT/ocean_solo.res:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_solo.res
+  hashes:
+    binhash: 6d93d239ade592f4325ce3a79102eed2
+    md5: 2b1c789b3ff6389a05a769a0d0934334
+work/ocean/INPUT/ocean_temp_salt.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_temp_salt.res.nc
+  hashes:
+    binhash: 5a4781cfb2b3e602fe708431e89727bf
+    md5: d59017739edb08299afe542567f73095
+work/ocean/INPUT/ocean_thickness.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_thickness.res.nc
+  hashes:
+    binhash: da6a5690d12f13a967098db7e56bdba1
+    md5: 67be2b864dcb5e643aa2b80ae44e78ca
+work/ocean/INPUT/ocean_tracer.res:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_tracer.res
+  hashes:
+    binhash: 273e80558f0528c2c5d351b8c168f1b1
+    md5: 4d105dfe1fba502278db9e80d5ec1dae
+work/ocean/INPUT/ocean_velocity.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity.res.nc
+  hashes:
+    binhash: 94b128539f24f252dfe03d6a8c3e7f64
+    md5: bc927019d11866a8ae67cb5bd5ddec93
+work/ocean/INPUT/ocean_velocity_advection.res.nc:
+  fullpath: /g/data/vk83/experiments/inputs/access-esm1p5/modern/historical/restart/ocean/ocean_velocity_advection.res.nc
+  hashes:
+    binhash: 03d9e461c0eab0d3d4f5a375fd84237a
+    md5: 2183be2ef353d129f56688247b0fbf3d


### PR DESCRIPTION
This pull request updates the input paths for the historical configuration with the restructured filepaths, relating to #37.

The md5 hash for `cableCMIP6_LC_1850-2015.nc` has changed due to the changes in  #22.

The md5 hashes for the following input files:
- `BC_hi_1849_2015_ESM1.anc`
- `Bio_1849_2015_ESM1.anc`
- `OCFF_1849_2015_ESM1.anc`
- `ozone_1849_2015_ESM1.anc`
- `scycl_1849_2015_ESM1_v4.anc`

have changed as the `vk83` version of these files are sourced from `/g/data/access/payu/access-esm/input/historical.corrected/` rather than `/g/data/access/payu/access-esm/input/historical/`. These then match the ancillaries from the CMIP6 script runs located in `/g/data/p66/txz599/data/ancil/CMIP6/`. See [here](https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/22#issuecomment-2192792090) for details.

The md5 hash for `bgc_param.nc` changed because of the modifications described [here](https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/2#issuecomment-2227522666).

Several unused input files were also removed.
