### PR TITLE
Updated `model-config-tests` to `0.0.4`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.3",
+        "model-config-tests-version": "0.0.4",
         "python-version": "3.11.0"
     }
 }


### PR DESCRIPTION
In this PR:
* Update the version of `model-config-tests` used to `0.0.4` - bugfixes to valid testing values

See referenced https://github.com/ACCESS-NRI/model-config-tests/pull/43