### PR TITLE
Update `model-config-tests` version to `0.0.5`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.4",
+        "model-config-tests-version": "0.0.5",
         "python-version": "3.11.0"
     }
 }


### PR DESCRIPTION
In this PR:
* Update the version of `model-config-tests` used to `0.0.5` - in which there are further fixes to QA tests for metadata.yaml. 

References https://github.com/ACCESS-NRI/model-config-tests/pull/45