### PR TITLE
Update `model-config-tests` to `0.0.6`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.5",
+        "model-config-tests-version": "0.0.6",
         "python-version": "3.11.0"
     }
 }


### PR DESCRIPTION
See changes here: https://github.com/ACCESS-NRI/model-config-tests/pull/46

In this PR:
* Update `model-config-tests` used to new `0.0.6`