### PR TITLE
Update model-config-tests to `0.0.7`

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -16,7 +16,7 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.0.6",
+        "model-config-tests-version": "0.0.7",
         "python-version": "3.11.0"
     }
 }


### PR DESCRIPTION
Update the version of `model-config-tests` to `0.0.7` -  see https://github.com/ACCESS-NRI/model-config-tests/pull/47