### PR TITLE
Don't run land use change on simulations shorter than a year.

### DIFF
--- a/scripts/update_landuse_driver.sh
+++ b/scripts/update_landuse_driver.sh
@@ -3,7 +3,14 @@ set -eu
 
 # Update land use fields in the end of year restart
 # This file will have a name of form aiihca.da??110
-./scripts/update_landuse.py work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc work/atmosphere/aiihca.da??110
+year_end_restart=work/atmosphere/aiihca.da??110
+
+if [ -f $end_year_file ]; then
+    ./scripts/update_landuse.py work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc $year_end_restart
+else
+    echo "Warning: No atmosphere end of year restart file found. update_landuse.py will not be run." >&2 
+fi
+
 if [[ $? != 0 ]]; then
     echo "Error from update_landuse.py" >&2
     exit 1

--- a/scripts/update_landuse_driver.sh
+++ b/scripts/update_landuse_driver.sh
@@ -5,7 +5,7 @@ set -eu
 # This file will have a name of form aiihca.da??110
 year_end_restart=work/atmosphere/aiihca.da??110
 
-if [ -f $end_year_file ]; then
+if [ -f $year_end_restart ]; then
     ./scripts/update_landuse.py work/atmosphere/INPUT/cableCMIP6_LC_1850-2015.nc $year_end_restart
 else
     echo "Warning: No atmosphere end of year restart file found. update_landuse.py will not be run." >&2 


### PR DESCRIPTION
This PR will close #56. It adds a check to see whether an end of year restart exists before running the `update_landuse.py` script, which will allow reproducibility tests to be done with shorter runs.

If no end of year restart exists, I've added in a warning message – though any suggestions on what the message should say are welcome.

Let me know if you have any suggestions/improvements!

Note that this change doesn't resolve issues related to non-standard run lengths (such as 8 months or 2 years), which will be looked at in a separate issue.