### PR TITLE
Update payu version in CI

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -18,6 +18,6 @@
     "default": {
         "model-config-tests-version": "0.0.7",
         "python-version": "3.11.0",
-        "payu-version": "1.1.4"
+        "payu-version": "1.1.5"
     }
 }


### PR DESCRIPTION
We need an updated version of `payu` to support ACCESS-ESM1.5.

Once this version has been deployed when https://github.com/ACCESS-NRI/payu-condaenv/pull/41#pullrequestreview-2256165092 is merged, this PR also needs to be merged.