### PR TITLE
Add netcdf conversion to preindustrial configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -160,4 +160,4 @@ sync:
 
 # userscripts:
 
-postscript: -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh $PAYU_CURRENT_OUTPUT_DIR  # -delete-ff
+postscript: -lstorage=${PBS_NCI_STORAGE} -v PAYU_CURRENT_OUTPUT_DIR ./scripts/NetCDF-conversion/UM_conversion_job.sh

--- a/config.yaml
+++ b/config.yaml
@@ -160,4 +160,4 @@ sync:
 
 # userscripts:
 
-postscript: -V -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh
+postscript: -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh $PAYU_CURRENT_OUTPUT_DIR  # -delete-ff

--- a/config.yaml
+++ b/config.yaml
@@ -160,4 +160,4 @@ sync:
 
 # userscripts:
 
-# postscript:
+postscript: -V -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh

--- a/config.yaml
+++ b/config.yaml
@@ -160,4 +160,4 @@ sync:
 
 # userscripts:
 
-postscript: -lstorage=${PBS_NCI_STORAGE} -v PAYU_CURRENT_OUTPUT_DIR ./scripts/NetCDF-conversion/UM_conversion_job.sh
+postscript: -v PAYU_CURRENT_OUTPUT_DIR,PROJECT  -lstorage=${PBS_NCI_STORAGE} ./scripts/NetCDF-conversion/UM_conversion_job.sh

--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -9,4 +9,7 @@
 module use /g/data/vk83/modules
 module load payu
 
+# Command below calls https://github.com/ACCESS-NRI/um2nc-standalone/blob/main/umpost/conversion_driver_esm1p5.py
+# By default UM atmosphere fields files are deleted after conversion to save space. 
+# Remove --delete-ff command line option to retain original files for testing purposes
 esm1p5_convert_nc $PAYU_CURRENT_OUTPUT_DIR --delete-ff

--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -6,4 +6,7 @@
 #PBS -l walltime=00:40:00
 #PBS -l wd
 
-esm1p5_convert_nc $PAYU_CURRENT_OUTPUT_DIR 
+module use /g/data/vk83/prerelease/modules
+module load payu
+
+esm1p5_convert_nc "$@" 

--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -6,7 +6,7 @@
 #PBS -l walltime=00:40:00
 #PBS -l wd
 
-module use /g/data/vk83/prerelease/modules
+module use /g/data/vk83/modules
 module load payu
 
 esm1p5_convert_nc $PAYU_CURRENT_OUTPUT_DIR --delete-ff

--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#PBS -l ncpus=1
+#PBS -l mem=20GB
+#PBS -l jobfs=0GB
+#PBS -q normal
+#PBS -l walltime=00:40:00
+#PBS -l wd
+
+esm1p5_convert_nc $PAYU_CURRENT_OUTPUT_DIR 

--- a/scripts/NetCDF-conversion/UM_conversion_job.sh
+++ b/scripts/NetCDF-conversion/UM_conversion_job.sh
@@ -9,4 +9,4 @@
 module use /g/data/vk83/prerelease/modules
 module load payu
 
-esm1p5_convert_nc "$@" 
+esm1p5_convert_nc $PAYU_CURRENT_OUTPUT_DIR --delete-ff


### PR DESCRIPTION
This pull request adds the um2nc based netcdf conversion as a postscript to the preindustrial configuration. Fields file deletion is switched on by default.