### PR TITLE
57 landuse python interpreter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,9 +19,6 @@ laboratory: access-esm
 jobname: historical
 queue: normal
 walltime: 2:30:00
-storage:
-  gdata:
-    - hh5
 
 # Modules for loading model executables
 modules:

--- a/scripts/update_landuse.py
+++ b/scripts/update_landuse.py
@@ -1,4 +1,4 @@
-#!/g/data/hh5/public/apps/nci_scripts/python-analysis3
+#!/usr/bin/env python3
 # Copyright 2020 Scott Wales
 # author: Scott Wales <scott.wales@unimelb.edu.au>
 #

--- a/scripts/update_landuse_driver.sh
+++ b/scripts/update_landuse_driver.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eu
 
+module use /g/data/vk83/modules
+module load payu
+
 # Update land use fields in the end of year restart
 # This file will have a name of form aiihca.da??110
 year_end_restart=work/atmosphere/aiihca.da??110


### PR DESCRIPTION
This pull request adds a workaround for #57, it replaces the python interpreter in the `update_landuse.py` script to `#!/usr/bin/env python3`, and loads the `payu` environment in the driving `update_landuse_driver.sh` script, to ensure the payu python interpreter is used. 

The `hh5` storage directive is also removed from the `config.yaml` as it is no longer needed.