### PR TITLE
Hard code python interpreter path in landuse change script

### DIFF
--- a/scripts/update_landuse.py
+++ b/scripts/update_landuse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/g/data/vk83/apps/payu/1.1.5/bin/python
 # Copyright 2020 Scott Wales
 # author: Scott Wales <scott.wales@unimelb.edu.au>
 #

--- a/scripts/update_landuse_driver.sh
+++ b/scripts/update_landuse_driver.sh
@@ -1,8 +1,5 @@
-#!/bin/bash -l
+#!/bin/bash
 set -eu
-
-module use /g/data/vk83/modules
-module load payu
 
 # Update land use fields in the end of year restart
 # This file will have a name of form aiihca.da??110

--- a/scripts/update_landuse_driver.sh
+++ b/scripts/update_landuse_driver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -l
 set -eu
 
 module use /g/data/vk83/modules


### PR DESCRIPTION
Fixes #67 

Removes `module use` that was throwing an error and hard-codes a python interpreter path in the update landuse python script.

I have tested this doesn't throw an error. I have not tested that it runs correctly after a 1 year run. 