### PR TITLE
Update to `access-esm1p5` 2024.05.1: `preindustrial+concentrations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# preindustiral+concentrations
-Standard configuration for a coupled CO~2~ concentration driven [ACCESS-ESM1.5](https://github.com/ACCESS-NRI/ACCESS-ESM1.5) under pre-industrial forcings.
+# preindustrial+concentrations
+Standard configuration for a coupled CO<sub>2</sub> concentration driven [ACCESS-ESM1.5](https://github.com/ACCESS-NRI/ACCESS-ESM1.5) under pre-industrial forcings.
 
 For usage instructions, see the [ACCESS-Hive docs](https://access-hive.org.au/models/run-a-model/run-access-esm/)
 

--- a/config.yaml
+++ b/config.yaml
@@ -25,7 +25,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-esm1p5/2024.05.0
+      - access-esm1p5/2024.05.1
 
 # Model configuration
 model: access
@@ -73,8 +73,6 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/dust.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
-        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
-        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
         # Tides
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -12,7 +12,7 @@ work/ice/cice_access_360x300_12x1_12p.exe:
     binhash: 818f213e53d30fc307b565c35939382c
     md5: 04fd88249ebc16e3f560fc265838e9d1
 work/ocean/fms_ACCESS-CM.x:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.06.20_access-esm1.5-wxxrc3ivrjz76yx565ddkuuiwoqpalko/bin/fms_ACCESS-CM.x
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.08.23_access-esm1.5-ougudnkjcdkuuu6wuxne3uy7tr4y6oes/bin/fms_ACCESS-CM.x
   hashes:
-    binhash: a7a3151fb1b814f9e94f05e637b86a44
-    md5: 241db68e6164fac77c59da99ffb1d3b1
+    binhash: 711dd9e382eee06aba1f38ce83f7e7d5
+    md5: 96863931103def85ed76b152ba01b5c1

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -311,21 +311,11 @@ work/ocean/INPUT/grid_spec.nc:
   hashes:
     binhash: 20468cf509d14ec15c908f7fbd8b3de5
     md5: b9adc1e552201aa3abc6efb72786ec93
-work/ocean/INPUT/ocmip2_fice_monthly_om1p5_bc.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_fice_monthly_om1p5_bc.nc
-  hashes:
-    binhash: 60f4723017d75ebe8a5bc5fe0f37ad1d
-    md5: c0ed75eef44962dbe6fc9f61dbd228a9
 work/ocean/INPUT/ocmip2_press_monthly_om1p5_bc.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_press_monthly_om1p5_bc.nc
   hashes:
     binhash: d4b3605e8765d477b02a55d6ae21feac
     md5: 2e71cbb78c052e06e3df20f862928da2
-work/ocean/INPUT/ocmip2_xkw_monthly_om1p5_bc.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/unused/ocean/biogeochemistry/global.1deg/2020.05.19/ocmip2_xkw_monthly_om1p5_bc.nc
-  hashes:
-    binhash: 39f04199eedf0e3a6c638d890795311e
-    md5: 348a035bed83e280bb0a1de0066947fc
 work/ocean/INPUT/roughness_amp.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
   hashes:

--- a/manifests/restart.yaml
+++ b/manifests/restart.yaml
@@ -89,6 +89,12 @@ work/ice/RESTART/mice.nc-01001231:
   hashes:
     binhash: 86630cac8e3acfb2d69f60a6d0e1e40b
     md5: 380a7008500f58eb5e8006b1eac18527
+work/ice/RESTART/restart_date.nml:
+  copy: true
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ice/restart_date.nml
+  hashes:
+    binhash: 17fac552938796d021d131b8b5c0f191
+    md5: da5f6db5c1b2dac11f27446f21db08cb
 work/ocean/INPUT/csiro_bgc.res.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/pre-industrial/restart/ocean/csiro_bgc.res.nc
   hashes:


### PR DESCRIPTION
Updates to `access-esm1p5` 2024.05.1 which allows us to remove usused BGC inputs. Also fixes a small typo in the README.

Will cherry-pick to `historical+concentrations` once merged.

Closes #78 