### PR TITLE
Preindustrial - increase jobfs to 1500MB

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,7 @@ laboratory: access-esm
 jobname: pre-industrial
 queue: normal
 walltime: 2:30:00
+jobfs: 1500MB
 
 # Modules for loading model executables
 modules:


### PR DESCRIPTION
This pull request increases the `jobfs` requested for the historical configuration to `1500MB` from the default `800MB`, with the goal of avoiding `jobfs exceeded` errors. 

Closes preindustrial half of #83.