### PR TITLE
Added `on.create` Trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' || (github.event_name == 'create' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' || (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 run-name: CI (${{ github.event_name }}) for ${{ github.ref_name }}
 on:
+  # For config-pr-1-ci.yml
   pull_request:
     branches:
       - 'release-*'
@@ -13,15 +14,19 @@ on:
       - config/**
       - .*
       - README.md
+  # For config-pr-2-confirm.yml
+  issue_comment:
+    types:
+      - created
+      - edited
+  # For config-pr-3-bump-tag.yml
+  create:
   push:
     branches:
       - 'release-*'
     paths:
       - 'metadata.yaml'
-  issue_comment:
-    types:
-      - created
-      - edited
+
 jobs:
   pr:
     name: PR
@@ -31,7 +36,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write  # For pull request comments denoting failure of the workflow
-      checks: write
+      checks: write  # For results of tests as a check
 
   pr-comment:
     name: Comment
@@ -44,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: github.event_name == 'push' || (github.event_name == 'create' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
   bump-tag:
     name: Tag Bump
-    if: github.event_name == 'push' || (github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
+    if: (github.event_name == 'push' || github.event_name == 'create' && github.ref_type == 'branch' && startsWith(github.ref_name, 'release-')) && github.repository != 'ACCESS-NRI/model-configs-template'
     uses: access-nri/model-config-tests/.github/workflows/config-pr-3-bump-tag.yml@main
     secrets: inherit
     permissions:


### PR DESCRIPTION
In this PR:
- Added `on.create` trigger from https://github.com/ACCESS-NRI/model-configs-template/commit/a1988f076af334d23da3e903b490e6a24f0421bf (from ACCESS-NRI/model-configs-template#3)

NOTE: We only have to add this CI to `main` (and not other `dev-*`/`release-*` branches) because only future configurations (which are based on `ci.yml` from `main`) will require this feature. 

References ACCESS-NRI/model-config-tests#58

