### PR TITLE
Historical: add basin mask for basin specific diagnostics 

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,6 +83,8 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
         # Grids
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
+        # Basin mask
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/basins/global.1deg/2020.05.19/basin_mask.nc
 
     - name: ice
       model: cice

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -56,11 +56,6 @@ work/atmosphere/INPUT/STASHmaster/STASHsections_A:
   hashes:
     binhash: 9401083e4199439b77254fc490b6597d
     md5: 8525fd107dbea6184db74089f1d55fd9
-work/atmosphere/INPUT/STASHmaster/manifest.yaml:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/manifest.yaml
-  hashes:
-    binhash: 0c5b7b98f44c8244eb5e3546ddd14ffc
-    md5: a0ed46f7a89e54ec91453533d4b3552e
 work/atmosphere/INPUT/TSI_CMIP6_ESM_v2:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
   hashes:
@@ -231,11 +226,6 @@ work/atmosphere/INPUT/stasets/X01010206:
   hashes:
     binhash: a7c6cf46b049f520547eab48654687ad
     md5: 7d5e82e70a2f3936743eb957462d41aa
-work/atmosphere/INPUT/stasets/manifest.yaml:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/manifest.yaml
-  hashes:
-    binhash: cf50bcba87ce5beea01a939180dc71f2
-    md5: e179226d2f2de9a224051d04ffa5ed84
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -56,6 +56,11 @@ work/atmosphere/INPUT/STASHmaster/STASHsections_A:
   hashes:
     binhash: 9401083e4199439b77254fc490b6597d
     md5: 8525fd107dbea6184db74089f1d55fd9
+work/atmosphere/INPUT/STASHmaster/manifest.yaml:
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/manifest.yaml
+  hashes:
+    binhash: 0c5b7b98f44c8244eb5e3546ddd14ffc
+    md5: a0ed46f7a89e54ec91453533d4b3552e
 work/atmosphere/INPUT/TSI_CMIP6_ESM_v2:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
   hashes:
@@ -226,6 +231,11 @@ work/atmosphere/INPUT/stasets/X01010206:
   hashes:
     binhash: a7c6cf46b049f520547eab48654687ad
     md5: 7d5e82e70a2f3936743eb957462d41aa
+work/atmosphere/INPUT/stasets/manifest.yaml:
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/manifest.yaml
+  hashes:
+    binhash: cf50bcba87ce5beea01a939180dc71f2
+    md5: e179226d2f2de9a224051d04ffa5ed84
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38
   hashes:
@@ -306,6 +316,11 @@ work/ice/INPUT/monthly_sstsss.nc:
   hashes:
     binhash: 49aab10f25c58a9a0ffa5617847050ff
     md5: 323d4c605f83f4d7d3126da70153c2ed
+work/ocean/INPUT/basin_mask.nc:
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/basins/global.1deg/2020.05.19/basin_mask.nc
+  hashes:
+    binhash: 98462c5ebc1edda0f42ca61be74801e6
+    md5: 20fd8740f24ca95c7c086343077e9c0d
 work/ocean/INPUT/bgc_param.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/ocean/biogeochemistry/global.1deg/2024.07.12/bgc_param.nc
   hashes:

--- a/ocean/input.nml
+++ b/ocean/input.nml
@@ -486,6 +486,7 @@
  &ocean_tracer_advect_nml
       debug_this_module=.false.
       advect_sweby_all=.true.
+      read_basin_mask=.true.
 /
 
  &ocean_tracer_diag_nml


### PR DESCRIPTION
Closes the historical half of https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/95.

This PR sets MOM to read the basin_mask.nc input file which allows for basin specific tracer diagnostics (e.g.  temp_merid_flux_over_atlantic) to be saved.