### PR TITLE
Add minimum payu 1.1.6 - preindustrial

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -144,7 +144,7 @@ manifest:
   reproduce:
     exe: True
 
-
+payu_minimum_version: 1.1.6
 stacksize: unlimited
 qsub_flags: -W umask=027
 


### PR DESCRIPTION
Closes the preindustrial half of #111. This PR adds `payu_minimum_version: 1.1.6` to the config.yaml file to make sure the cice restart date bugfixes from https://github.com/payu-org/payu/pull/539 are included.
