### PR TITLE
Historical: update model version to 2024.12.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-esm1p5/2024.05.1
+      - access-esm1p5/2024.12.0
 
 # Model configuration
 model: access

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.07.03_access-esm1.5-kgxooyp2s476dd4zc5mgtwhxfknkhnoe/bin/um_hg3.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.10.17_access-esm1.5-l3w5m5ub4qkaai4rqsrixyeggwvenqeg/bin/um_hg3.exe
   hashes:
-    binhash: 3180dda616c7dfe63d8134e00bff2641
-    md5: 1b7874ffb5e34ec50b6a68abbb7769a6
+    binhash: 7d84592b11262545ecbe8a9d10f69055
+    md5: 93c8bca8d07dd29b94e0a62ffc31c4f6
 work/ice/cice_access_360x300_12x1_12p.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.2024.05.21_access-esm1.5-hhtnigwxdyz7ta4dv3gvhwulze6hxqra/bin/cice_access_360x300_12x1_12p.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.2024.05.21_access-esm1.5-izhg4i36v6nzwulk5doeb2b4tv7dvjpg/bin/cice_access_360x300_12x1_12p.exe
   hashes:
-    binhash: 818f213e53d30fc307b565c35939382c
-    md5: 04fd88249ebc16e3f560fc265838e9d1
+    binhash: 4e0b0196ffa6cd59c554682ca6cd60bb
+    md5: 0bf593b74adb9060885fc875fa5fe23b
 work/ocean/fms_ACCESS-CM.x:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.08.23_access-esm1.5-ougudnkjcdkuuu6wuxne3uy7tr4y6oes/bin/fms_ACCESS-CM.x
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.08.23_access-esm1.5-m5h4mmwug6umrm7iqqvctnvsy4hwp2wv/bin/fms_ACCESS-CM.x
   hashes:
-    binhash: 711dd9e382eee06aba1f38ce83f7e7d5
-    md5: 96863931103def85ed76b152ba01b5c1
+    binhash: 794da19ceaf34a3babb2b24d96b9b018
+    md5: 86fd7c5105c40f8524cee935718a2138


### PR DESCRIPTION
This PR updates the model version to 2024.12.0 in order to include the UM orbital parameter code changes. It closes the historical half of https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/114.