### PR TITLE
Update input manifest for modified stash files - Historical

### DIFF
--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -27,34 +27,14 @@ work/atmosphere/INPUT/OCFF_1849_2015_ESM1.anc:
     binhash: c80d56183157d220322253672fc9198b
     md5: 1e38cac3a03101fb5aa5d88c713e809c
 work/atmosphere/INPUT/STASHmaster/STASHmaster_A:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/STASHmaster/STASHmaster_A
   hashes:
-    binhash: 4f75001536d84c87362b607aa42c4f61
-    md5: 74cbbb76edfbd9f7c4b928609c00cd64
-work/atmosphere/INPUT/STASHmaster/STASHmaster_A.original:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_A.original
-  hashes:
-    binhash: c7d3efdc2ca645724064afc4f7e655f6
-    md5: ed1004d9aca8d29baba143ea12defbb7
-work/atmosphere/INPUT/STASHmaster/STASHmaster_O:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_O
-  hashes:
-    binhash: 763bf187687a18a505264b4b79d40153
-    md5: 5a65d77c62d55e3b62e35ad9662d32a9
-work/atmosphere/INPUT/STASHmaster/STASHmaster_S:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_S
-  hashes:
-    binhash: 6d6eb7e1e0f21e635e532202f7b8d462
-    md5: 85ff5d563968cf24d1be595b05b4e52d
-work/atmosphere/INPUT/STASHmaster/STASHmaster_W:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHmaster_W
-  hashes:
-    binhash: 919a2c8987bd593c78153ff323efeb51
-    md5: 1e4391ea1f6234b33c33168bd7089d06
+    binhash: 8824ec1b804085ece05ebfe7a92c18cc
+    md5: cf6317cb10867acc54d4893388b1cb81
 work/atmosphere/INPUT/STASHmaster/STASHsections_A:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/STASHmaster/STASHsections_A
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/STASHmaster/STASHsections_A
   hashes:
-    binhash: 9401083e4199439b77254fc490b6597d
+    binhash: 54c3d83f4f1bf0df8403174944517901
     md5: 8525fd107dbea6184db74089f1d55fd9
 work/atmosphere/INPUT/TSI_CMIP6_ESM_v2:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/historical/atmosphere/forcing/resolution_independent/2021.06.22/TSI_CMIP6_ESM_v2
@@ -127,104 +107,104 @@ work/atmosphere/INPUT/spec3a_sw_hadgem1_6on:
     binhash: 149899ecc54ed754ab8c6f05cb99f140
     md5: 0e74c13cf3333132f38d8c5c52e1c7eb
 work/atmosphere/INPUT/stasets/X01001218:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01001218
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01001218
   hashes:
-    binhash: cef321aa4d4eeae2d156db854ce276c4
+    binhash: daa76313bc88d366a53e078b42b61f6d
     md5: 7293caa27798d235bd5520eede9700fb
 work/atmosphere/INPUT/stasets/X01002207:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01002207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01002207
   hashes:
-    binhash: 4e7a1dc7a52a0aab1da67b9328510fb5
+    binhash: 8f8c9ffa00059902143a104d4c73d722
     md5: 448daeebba685950d0c347d0493b5fc4
 work/atmosphere/INPUT/stasets/X01003236:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003236
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003236
   hashes:
-    binhash: 5cdf6aea7e61410df48d3cac8469454d
+    binhash: 5559443f5ea2a9f6f6104ffd534820fb
     md5: 71a2288ee0a7d0fc89dafe95653c128a
 work/atmosphere/INPUT/stasets/X01003237:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003237
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003237
   hashes:
-    binhash: 883c4ddd6d137ac441bf6c045c8a1c39
+    binhash: 701b084cf9c471fec34bff08159b0c41
     md5: 4efd39ac9a917525bbc35146d6770e3b
 work/atmosphere/INPUT/stasets/X01003254:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003254
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003254
   hashes:
-    binhash: e6db920da74cdf06c3c32053d778e9f3
+    binhash: 2e314c651d62051020e8bea3108ebb37
     md5: 1b5f7755f752c2ee2086ac6eba886ca3
 work/atmosphere/INPUT/stasets/X01003255:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003255
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003255
   hashes:
-    binhash: 9b804470b184c2e3a143a64314b4baf3
+    binhash: 74feaa18766e3a2e97527171a449394b
     md5: f23a78b048f0cb52ed0e2beb57f00fa8
 work/atmosphere/INPUT/stasets/X01003274:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003274
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003274
   hashes:
-    binhash: a999c69b36a2f7d183e8b9fce0b17dba
+    binhash: 2d2eee6660a69a3ef30f8d2cef16c184
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003275:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003275
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003275
   hashes:
-    binhash: 24c47dd90d0a17b6fa81e48133f310e3
+    binhash: b89a1b861dad967c307aefa09d883613
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003276:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003276
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003276
   hashes:
-    binhash: 9c8d8aa71ac65ee098ac3a50f00007c3
+    binhash: 5376763ac37ec1dbde79986e6cedd48f
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003277:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003277
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003277
   hashes:
-    binhash: da58ccbd06fe6cf6987f8eef37590c70
+    binhash: e7e01d225bf29117567f2ce7e027a2a7
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003278:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003278
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003278
   hashes:
-    binhash: 5a899ad334e42cc3cdd1ab14429299ed
+    binhash: 69ba847420e01335923e1ddf243cad4f
     md5: 032190f23c926eb47199da6e1f054bf1
 work/atmosphere/INPUT/stasets/X01003279:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003279
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003279
   hashes:
-    binhash: a43fcc064f100a634326d53110ab8fe2
+    binhash: 283657078f88b1266f22f08533427e07
     md5: 120694f3d078b9ade033b56217e9ed85
 work/atmosphere/INPUT/stasets/X01003280:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003280
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003280
   hashes:
-    binhash: 05b3ac5c90fdf71e906e3b6e0dcf3329
+    binhash: f440ad8823420d70b082acebf92a6fa0
     md5: 61afb6eb4e76efb2171c56d02742e9ad
 work/atmosphere/INPUT/stasets/X01003281:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003281
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003281
   hashes:
-    binhash: 990649b208fa059df477aef96d2242a0
+    binhash: 5e57fe5c6a727b8fa1db43305a032190
     md5: d8cced93214dd8e84c0c9d06259412ab
 work/atmosphere/INPUT/stasets/X01003286:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01003286
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01003286
   hashes:
-    binhash: 731b64153656addbd7bd29b98e60906a
+    binhash: 3018709c1b4def9c74c59006d083b5cf
     md5: 062ab130605e4771a89b2a300a6154bf
 work/atmosphere/INPUT/stasets/X01005207:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005207
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01005207
   hashes:
-    binhash: 52ae55398cdcdf5582bd6253755c5185
+    binhash: c40e89a324ab47f4ca62cddfc970d90c
     md5: 3d1ccb47257c379b909e8d6098ab95a0
 work/atmosphere/INPUT/stasets/X01005208:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005208
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01005208
   hashes:
-    binhash: 4d114e56511e247ca65b4bd79cd66437
+    binhash: d48546fe5148b1ff16bcdf104cb94466
     md5: 8685052394200b839f115a667e7890ff
 work/atmosphere/INPUT/stasets/X01005222:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005222
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01005222
   hashes:
-    binhash: 115879288e4fe41cf3aa936793597f0a
+    binhash: 83cbc20957451004fb117100916223eb
     md5: 3edd8e46166dbed4102c329991a7a497
 work/atmosphere/INPUT/stasets/X01005223:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01005223
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01005223
   hashes:
-    binhash: b0707253914846f3a526030c52a818fe
+    binhash: bae1a14b765ed89473c6bddc3dc2df29
     md5: 4633fea316272fd71cd823881d100c14
 work/atmosphere/INPUT/stasets/X01010206:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2020.05.19/stasets/X01010206
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/share/atmosphere/stash/2024.11.01/stasets/X01010206
   hashes:
-    binhash: a7c6cf46b049f520547eab48654687ad
+    binhash: 77887f2ee61bce61e1d8c54364aa143b
     md5: 7d5e82e70a2f3936743eb957462d41aa
 work/atmosphere/INPUT/sulpc_oxidants_N96_L38:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/atmosphere/aerosol/global.N96/2020.05.19/sulpc_oxidants_N96_L38


### PR DESCRIPTION
PR #108 Updated the inputs to use new STASH files for the historical configuration – unfortunately I forgot to add the corresponding update to the input manifetsts. This PR updates the manifests with the new files.