### PR TITLE
Add scheduled checks for release-historical+concentrations-1.2 and release-preindustrial+concentrations-1.2

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -1,6 +1,8 @@
 {
     "$schema": "https://github.com/ACCESS-NRI/schema/tree/main/au.org.access-nri/model/configuration/ci/2-0-0.json",
     "scheduled": {
+        "release-historical+concentrations-1.2": {},
+        "release-preindustrial+concentrations-1.2": {},
         "default": {
             "markers": "checksum"
         }


### PR DESCRIPTION
In this PR:
 - We add scheduled checks for the above config tags, so we test whether the continue to be reproducible with themselves month-to-month. 


