### PR TITLE
Update landuse script to use payu/1.1.6's python executable

### DIFF
--- a/scripts/update_landuse.py
+++ b/scripts/update_landuse.py
@@ -1,4 +1,4 @@
-#!/g/data/vk83/apps/payu/1.1.5/bin/python
+#!/g/data/vk83/apps/conda_scripts/payu-1.1.6.d/bin/python3
 # Copyright 2020 Scott Wales
 # author: Scott Wales <scott.wales@unimelb.edu.au>
 #


### PR DESCRIPTION
References #67. As it's still not currently possible to load modules in user-script, and/or have the payu conda environment available in the user-script that is called from a bash script, the workaround has been to explicitly set the python executable to the one in the payu environment. This PR updates this to payu/1.1.6. Note the executable path is a bit different, as it now launches a container to access python in the payu-1.1.6 conda environment.

Thanks to @blimlim for testing the script runs OK and produces identical results with the payu/1.1.5 version.

 