### PR TITLE
Revert update to landuse script python executable

### DIFF
--- a/scripts/update_landuse.py
+++ b/scripts/update_landuse.py
@@ -1,4 +1,4 @@
-#!/g/data/vk83/apps/conda_scripts/payu-1.1.6.d/bin/python3
+#!/g/data/vk83/apps/payu/1.1.5/bin/python
 # Copyright 2020 Scott Wales
 # author: Scott Wales <scott.wales@unimelb.edu.au>
 #


### PR DESCRIPTION
Revert update in https://github.com/ACCESS-NRI/access-esm1.5-configs/pull/125 to use the `payu/1.1.5` python executable. Using the `payu/1.1.6` python executable breaks when running with the `payu/dev` module (see https://github.com/ACCESS-NRI/access-esm1.5-configs/issues/67#issuecomment-2711994199).