### PR TITLE
Update to access-esm1.5 2024.12.1: `dev-preindustrial+concentrations`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ modules:
   use:
       - /g/data/vk83/modules
   load:
-      - access-esm1p5/2024.12.0
+      - access-esm1p5/2024.12.1
 
 # Model configuration
 model: access

--- a/manifests/exe.yaml
+++ b/manifests/exe.yaml
@@ -2,17 +2,17 @@ format: yamanifest
 version: 1.0
 ---
 work/atmosphere/um_hg3.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.10.17_access-esm1.5-l3w5m5ub4qkaai4rqsrixyeggwvenqeg/bin/um_hg3.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/um7-git.2024.10.17_access-esm1.5-heooehpezvblo6woeptrz4gkge5qv3uv/bin/um_hg3.exe
   hashes:
-    binhash: 7d84592b11262545ecbe8a9d10f69055
-    md5: 93c8bca8d07dd29b94e0a62ffc31c4f6
+    binhash: 50381bc82c482ae9b89f1b7ed923756b
+    md5: b3a8c05213ff7a7ea884226e2f75b7cd
 work/ice/cice_access_360x300_12x1_12p.exe:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.2024.05.21_access-esm1.5-izhg4i36v6nzwulk5doeb2b4tv7dvjpg/bin/cice_access_360x300_12x1_12p.exe
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/cice4-git.access-esm1.5-2025.04.001_access-esm1.5-xrdbhyidnlvynxpm7jezkmytgtzi7nqt/bin/cice_access_360x300_12x1_12p.exe
   hashes:
-    binhash: 4e0b0196ffa6cd59c554682ca6cd60bb
-    md5: 0bf593b74adb9060885fc875fa5fe23b
+    binhash: 9f87696423e3a8d46876aee9ec835655
+    md5: 2e5e07de8ac7ea0273867be2c68abd3f
 work/ocean/fms_ACCESS-CM.x:
-  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5_2024.08.23_access-esm1.5-m5h4mmwug6umrm7iqqvctnvsy4hwp2wv/bin/fms_ACCESS-CM.x
+  fullpath: /g/data/vk83/apps/spack/0.22/restricted/ukmo/release/linux-rocky8-x86_64_v4/intel-19.0.3.199/mom5-git.access-esm1.5-2025.03.002_access-esm1.5-xvkwyoqnbdq3byuttwtwghcbe4xpddmq/bin/fms_ACCESS-CM.x
   hashes:
-    binhash: 794da19ceaf34a3babb2b24d96b9b018
-    md5: 86fd7c5105c40f8524cee935718a2138
+    binhash: 0ecad7262fb4abc05a530917d96ecdc5
+    md5: 5e021cc45d29c3f8bdb5ae2f859fe383


### PR DESCRIPTION
This PR updates to access-esm1.5 2024.12.1, which includes:
- Updates MOM5 to [access-esm1.5-2025.03.002](https://github.com/ACCESS-NRI/MOM5/releases/tag/access-esm1.5-2025.03.002), which includes
  - WOMBAT fix to prevent negative Schmidt numbers in warm temperatures (https://github.com/ACCESS-NRI/MOM5/pull/36)
  - Updates for oneapi (https://github.com/ACCESS-NRI/MOM5/pull/32)
- Updates `spack-packages` to [2025.03.006](https://github.com/ACCESS-NRI/spack-packages/releases/tag/2025.03.006)
- Updates CICE4 to [access-esm1.5-2025.04.001](https://github.com/ACCESS-NRI/cice4/releases/tag/access-esm1.5-2025.04.001) which includes
  -  CICE error reporting changes so that error messages are written to stderr, and non-zero exit codes are used (https://github.com/ACCESS-NRI/cice4/pull/14)

Contributes to #131 