### PR TITLE
Update versions for model-config-tests and payu

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -18,8 +18,8 @@
         }
     },
     "default": {
-        "model-config-tests-version": "0.1.0",
+        "model-config-tests-version": "0.1.1",
         "python-version": "3.11.0",
-        "payu-version": "1.1.5"
+        "payu-version": "1.1.6"
     }
 }


### PR DESCRIPTION
A couple of recent changes to `model-config-tests` are needed for the esm1.5 configs. This PR updates the `ci.json` to latest versions of `model-config-tests` and `payu`