### PR TITLE
Preindustrial: Update ocean input ssw_atten_depth.nc

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -78,7 +78,7 @@ submodels:
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/roughness_amp.nc
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
         # Shortwave
-        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+        - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2025.06.23/ssw_atten_depth.nc
         # Grids
         - /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/grids/mosaic/global.1deg/2020.05.19/grid_spec.nc
         # Basin mask

--- a/manifests/input.yaml
+++ b/manifests/input.yaml
@@ -307,10 +307,10 @@ work/ocean/INPUT/roughness_amp.nc:
     binhash: 9283cb9b6093d7d9570797f360062d10
     md5: 185dadeb53da2de75b47c53fd7085f89
 work/ocean/INPUT/ssw_atten_depth.nc:
-  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2020.05.19/ssw_atten_depth.nc
+  fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/shortwave_penetration/global.1deg/2025.06.23/ssw_atten_depth.nc
   hashes:
-    binhash: 4a66b77be6d419706657e3fe3e5bf210
-    md5: 3e88b51db135788aa4348d58cbeabfad
+    binhash: c0ee1d830be4804dbc391e3c295634bc
+    md5: d195ac0cd1e3bdc5bf42476bf300169e
 work/ocean/INPUT/tideamp.nc:
   fullpath: /g/data/vk83/configurations/inputs/access-esm1p5/modern/share/ocean/tides/global.1deg/2020.05.19/tideamp.nc
   hashes:


### PR DESCRIPTION
This PR updates the ocean input `ssw_atten_depth.nc` to a new file with time units of `"days since 0001-01-01 00:00:00"` rather than `"days since 0000-01-01 00:00:00"`. This PR does not change answers.

See https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/105